### PR TITLE
Include defaults for properties required for the module

### DIFF
--- a/alfresco-indexer-webscripts/src/main/amp/config/alfresco/module/alfresco-indexer-webscripts/alfresco-global.properties
+++ b/alfresco-indexer-webscripts/src/main/amp/config/alfresco/module/alfresco-indexer-webscripts/alfresco-global.properties
@@ -1,0 +1,10 @@
+indexer.properties.url.template = http://localhost:8080/alfresco/service/node/details
+indexer.content.url.prefix = http://localhost:8080/alfresco/service
+indexer.share.url.prefix = http://localhost:8888/share
+indexer.preview.url.prefix = http://localhost:8080/alfresco/service
+indexer.thumbnail.url.prefix = http://localhost:8080/alfresco/service
+
+indexer.changes.nodesperacl=10
+indexer.changes.nodespertxn=10
+
+indexer.changes.allowedTypes={http://www.alfresco.org/model/content/1.0}content,{http://www.alfresco.org/model/content/1.0}folder


### PR DESCRIPTION
Include some default properties in the module that can be overridden.

This prevents errors upon startup of alfresco if these properties aren't defined within the normal global properties file.
