### PR TITLE
Replaces and with or in the while loop in addSeedDocuments

### DIFF
--- a/manifold-connector/src/main/java/org/alfresco/consulting/manifold/AlfrescoConnector.java
+++ b/manifold-connector/src/main/java/org/alfresco/consulting/manifold/AlfrescoConnector.java
@@ -126,7 +126,7 @@ public class AlfrescoConnector extends BaseRepositoryConnector {
         lastAclChangesetId = response.getLastAclChangesetId();
 
         logger.info("transaction_id={}, acl_changeset_id={}", lastTransactionId, lastAclChangesetId);
-      } while (transactionIdsProcessed > 0 && aclChangesetsProcessed > 0);
+      } while (transactionIdsProcessed > 0 || aclChangesetsProcessed > 0);
 
       logger.info("Recording {} as last transaction id and {} as last changeset id", lastTransactionId, lastAclChangesetId);
       return lastTransactionId + "|" + lastAclChangesetId;

--- a/manifold-connector/src/main/java/org/alfresco/consulting/manifold/AlfrescoConnector.java
+++ b/manifold-connector/src/main/java/org/alfresco/consulting/manifold/AlfrescoConnector.java
@@ -1,13 +1,26 @@
 package org.alfresco.consulting.manifold;
 
-import com.google.gson.Gson;
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.StringTokenizer;
+
 import org.alfresco.consulting.indexer.client.AlfrescoClient;
 import org.alfresco.consulting.indexer.client.AlfrescoDownException;
 import org.alfresco.consulting.indexer.client.AlfrescoResponse;
 import org.alfresco.consulting.indexer.client.WebScriptsAlfrescoClient;
 import org.apache.manifoldcf.agents.interfaces.RepositoryDocument;
 import org.apache.manifoldcf.agents.interfaces.ServiceInterruption;
-import org.apache.manifoldcf.core.interfaces.*;
+import org.apache.manifoldcf.core.interfaces.ConfigParams;
+import org.apache.manifoldcf.core.interfaces.DBInterfaceFactory;
+import org.apache.manifoldcf.core.interfaces.IDBInterface;
+import org.apache.manifoldcf.core.interfaces.IHTTPOutput;
+import org.apache.manifoldcf.core.interfaces.IPostParameters;
+import org.apache.manifoldcf.core.interfaces.IThreadContext;
+import org.apache.manifoldcf.core.interfaces.ManifoldCFException;
+import org.apache.manifoldcf.core.interfaces.Specification;
 import org.apache.manifoldcf.crawler.connectors.BaseRepositoryConnector;
 import org.apache.manifoldcf.crawler.interfaces.DocumentSpecification;
 import org.apache.manifoldcf.crawler.interfaces.IProcessActivity;
@@ -15,12 +28,7 @@ import org.apache.manifoldcf.crawler.interfaces.ISeedingActivity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.StringTokenizer;
+import com.google.gson.Gson;
 
 public class AlfrescoConnector extends BaseRepositoryConnector {
   private static final Logger logger = LoggerFactory.getLogger(AlfrescoConnector.class);
@@ -97,7 +105,7 @@ public class AlfrescoConnector extends BaseRepositoryConnector {
   }
 
   @Override
-  public String addSeedDocumentsWithVersion(ISeedingActivity activities, Specification spec,
+  public String addSeedDocuments(ISeedingActivity activities, Specification spec,
                                               String lastSeedVersion, long seedTime, int jobMode) throws ManifoldCFException, ServiceInterruption {
     try {
       StringTokenizer tokenizer = new StringTokenizer(lastSeedVersion,"|");

--- a/manifold-connector/src/main/java/org/alfresco/consulting/manifold/AlfrescoConnector.java
+++ b/manifold-connector/src/main/java/org/alfresco/consulting/manifold/AlfrescoConnector.java
@@ -14,8 +14,6 @@ import org.alfresco.consulting.indexer.client.WebScriptsAlfrescoClient;
 import org.apache.manifoldcf.agents.interfaces.RepositoryDocument;
 import org.apache.manifoldcf.agents.interfaces.ServiceInterruption;
 import org.apache.manifoldcf.core.interfaces.ConfigParams;
-import org.apache.manifoldcf.core.interfaces.DBInterfaceFactory;
-import org.apache.manifoldcf.core.interfaces.IDBInterface;
 import org.apache.manifoldcf.core.interfaces.IHTTPOutput;
 import org.apache.manifoldcf.core.interfaces.IPostParameters;
 import org.apache.manifoldcf.core.interfaces.IThreadContext;
@@ -32,7 +30,6 @@ import com.google.gson.Gson;
 
 public class AlfrescoConnector extends BaseRepositoryConnector {
   private static final Logger logger = LoggerFactory.getLogger(AlfrescoConnector.class);
-  private static final String DATABASE_TABLE = "alfrescoconnector";
   private static final String ACTIVITY_FETCH = "fetch document";
   private static final String[] activitiesList = new String[]{ACTIVITY_FETCH};
   private AlfrescoClient alfrescoClient;
@@ -46,15 +43,6 @@ public class AlfrescoConnector extends BaseRepositoryConnector {
 
   void setClient(AlfrescoClient client) {
     alfrescoClient = client;
-  }
-
-  private IDBInterface getDb(IThreadContext threadContext) throws ManifoldCFException {
-    if (threadContext == null)
-      return null;
-    return DBInterfaceFactory.make(threadContext,
-            org.apache.manifoldcf.crawler.system.ManifoldCF.getMasterDatabaseName(),
-            org.apache.manifoldcf.crawler.system.ManifoldCF.getMasterDatabaseUsername(),
-            org.apache.manifoldcf.crawler.system.ManifoldCF.getMasterDatabasePassword());
   }
 
   @Override

--- a/manifold-connector/src/main/java/org/alfresco/consulting/manifold/AlfrescoConnector.java
+++ b/manifold-connector/src/main/java/org/alfresco/consulting/manifold/AlfrescoConnector.java
@@ -156,7 +156,11 @@ public class AlfrescoConnector extends BaseRepositoryConnector {
         if (this.enableDocumentProcessing) {
           processMetaData(rd,uuid);
         }
-        activities.ingestDocument(String.valueOf(uuid), "", uuid, rd);
+        try {
+            activities.ingestDocumentWithException(String.valueOf(uuid), "", uuid, rd);
+        } catch (IOException e) {
+            throw new ManifoldCFException("Caught IOException while ingesting document with uuid: " + uuid);
+        }
       }
     }
   }

--- a/manifold-connector/src/test/java/org/alfresco/consulting/manifold/AlfrescoConnectorTest.java
+++ b/manifold-connector/src/test/java/org/alfresco/consulting/manifold/AlfrescoConnectorTest.java
@@ -105,7 +105,7 @@ public class AlfrescoConnectorTest {
 
     ArgumentCaptor<RepositoryDocument> rd = ArgumentCaptor.forClass(RepositoryDocument.class);
     verify(activities)
-            .ingestDocument(eq(TestDocument.uuid), anyString(),
+            .ingestDocumentWithException(eq(TestDocument.uuid), anyString(),
                     eq(TestDocument.uuid), rd.capture());
 
     Iterator<String> i = rd.getValue().getFields();
@@ -127,7 +127,7 @@ public class AlfrescoConnectorTest {
     connector.processDocuments(new String[]{json}, null, activities, null, null, 0);
 
     verify(activities).deleteDocument(eq(TestDocument.uuid));
-    verify(activities, never()).ingestDocument(eq(TestDocument.uuid), anyString(), anyString(),
+    verify(activities, never()).ingestDocumentWithException(eq(TestDocument.uuid), anyString(), anyString(),
             any(RepositoryDocument.class));
 
   }

--- a/manifold-connector/src/test/java/org/alfresco/consulting/manifold/AlfrescoConnectorTest.java
+++ b/manifold-connector/src/test/java/org/alfresco/consulting/manifold/AlfrescoConnectorTest.java
@@ -1,5 +1,6 @@
 package org.alfresco.consulting.manifold;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
@@ -22,6 +23,7 @@ import org.apache.manifoldcf.agents.interfaces.RepositoryDocument;
 import org.apache.manifoldcf.core.interfaces.ManifoldCFException;
 import org.apache.manifoldcf.crawler.interfaces.DocumentSpecification;
 import org.apache.manifoldcf.crawler.interfaces.IProcessActivity;
+import org.apache.manifoldcf.crawler.interfaces.ISeedingActivity;
 import org.apache.manifoldcf.crawler.system.SeedingActivity;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,11 +58,23 @@ public class AlfrescoConnectorTest {
     DocumentSpecification spec = new DocumentSpecification();
     long seedTime = 1;
     int jobMode = 0;
- 
-    connector.addSeedDocuments(activities, spec, "0|0", seedTime, jobMode);
+    String lastSeedVersion = "0|0";
+
+    connector.addSeedDocuments(activities, spec, lastSeedVersion, seedTime, jobMode);
 
     verify(client).fetchNodes(anyInt(), anyInt());
   }
+
+    @Test
+    public void addSeedDocumentsWithOnlyAclChangeSetsShouldRetreiveAllChanges() throws Exception {
+        when(client.fetchNodes(anyInt(), anyInt()))
+                .thenReturn(new AlfrescoResponse(0L, 1L))
+                .thenReturn(new AlfrescoResponse(0L, 2L))
+                .thenReturn(new AlfrescoResponse(0L, 2L));
+        String lastSeedVersion = connector.addSeedDocuments(mock(ISeedingActivity.class),
+                new DocumentSpecification(), "0|0", 0L, 0);
+        assertEquals("0|2", lastSeedVersion);
+    }
 
   @Test
   public void whenTheClientIsCalledItShouldUseThePreviouslySentLastTransactionId() throws

--- a/manifold-connector/src/test/java/org/alfresco/consulting/manifold/AlfrescoConnectorTest.java
+++ b/manifold-connector/src/test/java/org/alfresco/consulting/manifold/AlfrescoConnectorTest.java
@@ -1,6 +1,21 @@
 package org.alfresco.consulting.manifold;
 
-import com.google.gson.Gson;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
 import org.alfresco.consulting.indexer.client.AlfrescoClient;
 import org.alfresco.consulting.indexer.client.AlfrescoResponse;
 import org.apache.manifoldcf.agents.interfaces.RepositoryDocument;
@@ -15,13 +30,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.util.*;
-
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import com.google.gson.Gson;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AlfrescoConnectorTest {
@@ -45,10 +54,10 @@ public class AlfrescoConnectorTest {
   public void whenAddingSeedDocumentTheAlfrescoClientShouldBeUsed() throws Exception {
     SeedingActivity activities = mock(SeedingActivity.class);
     DocumentSpecification spec = new DocumentSpecification();
-    long startTime = 1;
-    long endTime = 3;
-
-    connector.addSeedDocuments(activities, spec, startTime, endTime);
+    long seedTime = 1;
+    int jobMode = 0;
+ 
+    connector.addSeedDocuments(activities, spec, "0|0", seedTime, jobMode);
 
     verify(client).fetchNodes(anyInt(), anyInt());
   }
@@ -66,7 +75,7 @@ public class AlfrescoConnectorTest {
                     lastTransactionId, lastAclChangesetId));
 
     connector.addSeedDocuments(mock(SeedingActivity.class),
-            new DocumentSpecification(), 0, 0);
+            new DocumentSpecification(), "0|0", 0L, 0);
     verify(client, times(1)).fetchNodes(eq(firstTransactionId), eq(firstAclChangesetId));
 
     verify(client, times(1)).fetchNodes(eq(lastTransactionId), eq(lastAclChangesetId));
@@ -81,7 +90,7 @@ public class AlfrescoConnectorTest {
                     Arrays.<Map<String, Object>>asList(testDocument)));
 
     SeedingActivity seedingActivity = mock(SeedingActivity.class);
-    connector.addSeedDocuments(seedingActivity, new DocumentSpecification(), 0, 0);
+    connector.addSeedDocuments(seedingActivity, new DocumentSpecification(), "0|0", 0L, 0);
 
     String json = gson.toJson(testDocument);
     verify(seedingActivity).addSeedDocument(eq(json));


### PR DESCRIPTION
If only one of transactionId and lastChangesetId had changed some changes might not be fetched. Replacing && with || should fix that.

There are also some other updates to handle updates in the manifold connector api.
