### PR TITLE
Fixed NullPointerException in the first run of the job when the lastSeed...

### DIFF
--- a/alfresco-indexer-client/src/main/java/org/alfresco/consulting/indexer/client/AlfrescoClient.java
+++ b/alfresco-indexer-client/src/main/java/org/alfresco/consulting/indexer/client/AlfrescoClient.java
@@ -1,5 +1,6 @@
 package org.alfresco.consulting.indexer.client;
 
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
@@ -36,4 +37,12 @@ public interface AlfrescoClient {
    * @return a list of {@link AlfrescoUser}
    */
   List<AlfrescoUser> fetchAllUsersAuthorities() throws AlfrescoDownException;
+  
+  /**
+   * Fetches Document Binary Content
+   * 
+   * @param contentUrlPath URL of the content
+   * @return Document Binary Content
+   */
+  InputStream fetchContent(String contentUrlPath);
 }


### PR DESCRIPTION
...Version is NULL and there is no information about last transactions. Fixed by sending lastTransactionId=0 and lastAclChangesetId=0 in the first run.

Include a new Service in the Alfresco Client to get the binary content of the documents
