### PR TITLE
Inclusion of Filtering Rules at Job Level

### DIFF
--- a/alfresco-indexer-client/src/main/java/org/alfresco/consulting/indexer/client/AlfrescoClient.java
+++ b/alfresco-indexer-client/src/main/java/org/alfresco/consulting/indexer/client/AlfrescoClient.java
@@ -14,7 +14,7 @@ public interface AlfrescoClient {
    *         the id of the last transaction already being indexed; it can be considered a "startFrom" param
    * @return an {@link AlfrescoResponse}
    */
-  AlfrescoResponse fetchNodes(long lastTransactionId, long lastAclChangesetId) throws
+  AlfrescoResponse fetchNodes(long lastTransactionId, long lastAclChangesetId, AlfrescoFilters filters) throws
       AlfrescoDownException;
   
   /**

--- a/alfresco-indexer-client/src/main/java/org/alfresco/consulting/indexer/client/AlfrescoFilters.java
+++ b/alfresco-indexer-client/src/main/java/org/alfresco/consulting/indexer/client/AlfrescoFilters.java
@@ -3,35 +3,46 @@ package org.alfresco.consulting.indexer.client;
 import java.util.Collection;
 import java.util.Map;
 
+import org.json.simple.JSONObject;
+
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 public class AlfrescoFilters {
 
 	private Collection<String> siteFilters;
 	
+	private Collection<String> typeFilters;
+	
 	private Collection<String> mimetypeFilters;
 	
-	private Map<String, String> aspectFilters;
+	private Collection<String> aspectFilters;
 	
 	private Map<String, String> metadataFilters;
 	
 	public AlfrescoFilters(){
 		siteFilters = Sets.newHashSet();
+		typeFilters = Sets.newHashSet();
 		mimetypeFilters = Sets.newHashSet();
-		aspectFilters = Maps.newHashMap();
+		aspectFilters = Sets.newHashSet();
 		metadataFilters = Maps.newHashMap();
 	}
 
 	public Collection<String> getSiteFilters() {
 		return siteFilters;
 	}
+	
+	public Collection<String> getTypeFilters(){
+	    return typeFilters;
+	}
 
 	public Collection<String> getMimetypeFilters() {
 		return mimetypeFilters;
 	}
 
-	public Map<String, String> getAspectFilters() {
+	public Collection<String> getAspectFilters() {
 		return aspectFilters;
 	}
 
@@ -43,15 +54,26 @@ public class AlfrescoFilters {
 		siteFilters.add(site);
 	}
 	
+	public void addTypeFilter(String type){
+	    typeFilters.add(type);
+	}
+	
 	public void addMimetypeFilter(String mimetype){
 		mimetypeFilters.add(mimetype);
 	}
 	
-	public void addAspectFilter(String aspectName, String aspectValue){
-		aspectFilters.put(aspectName, aspectValue);
+	public void addAspectFilter(String aspect){
+		aspectFilters.add(aspect);
 	}
 	
 	public void addMetadataFilter(String metadata, String value){
 		metadataFilters.put(metadata, value);
+	}
+	
+	public  String toJSONString(){
+	    
+	    Gson gson= new GsonBuilder().create();
+	    return gson.toJson(this);
+	    
 	}
 }

--- a/alfresco-indexer-client/src/main/java/org/alfresco/consulting/indexer/client/AlfrescoFilters.java
+++ b/alfresco-indexer-client/src/main/java/org/alfresco/consulting/indexer/client/AlfrescoFilters.java
@@ -1,0 +1,57 @@
+package org.alfresco.consulting.indexer.client;
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+public class AlfrescoFilters {
+
+	private Collection<String> siteFilters;
+	
+	private Collection<String> mimetypeFilters;
+	
+	private Map<String, String> aspectFilters;
+	
+	private Map<String, String> metadataFilters;
+	
+	public AlfrescoFilters(){
+		siteFilters = Sets.newHashSet();
+		mimetypeFilters = Sets.newHashSet();
+		aspectFilters = Maps.newHashMap();
+		metadataFilters = Maps.newHashMap();
+	}
+
+	public Collection<String> getSiteFilters() {
+		return siteFilters;
+	}
+
+	public Collection<String> getMimetypeFilters() {
+		return mimetypeFilters;
+	}
+
+	public Map<String, String> getAspectFilters() {
+		return aspectFilters;
+	}
+
+	public Map<String, String> getMetadataFilters() {
+		return metadataFilters;
+	}
+	
+	public void addSiteFilter(String site){
+		siteFilters.add(site);
+	}
+	
+	public void addMimetypeFilter(String mimetype){
+		mimetypeFilters.add(mimetype);
+	}
+	
+	public void addAspectFilter(String aspectName, String aspectValue){
+		aspectFilters.put(aspectName, aspectValue);
+	}
+	
+	public void addMetadataFilter(String metadata, String value){
+		metadataFilters.put(metadata, value);
+	}
+}

--- a/alfresco-indexer-client/src/main/java/org/alfresco/consulting/indexer/client/WebScriptsAlfrescoClient.java
+++ b/alfresco-indexer-client/src/main/java/org/alfresco/consulting/indexer/client/WebScriptsAlfrescoClient.java
@@ -41,10 +41,7 @@ public class WebScriptsAlfrescoClient implements AlfrescoClient {
   
   private static final String URL_PARAM_LAST_TXN_ID = "lastTxnId";
   private static final String URL_PARAM_LAST_ACL_CS_ID = "lastAclChangesetId";
-  private static final String URL_PARAM_SITES_FILTER = "sitesFilter";
-  private static final String URL_PARAM_MIMETYPES_FILTER = "mimetypesFilter";
-  private static final String URL_PARAM_ASPECTS_FILTER = "aspectsFilter";
-  private static final String URL_PARAM_METADATA_FILTER = "metadataFilter";
+  private static final String URL_PARAM_INDEXING_FILTERS = "indexingFilters";
   
   private static final String STORE_ID = "store_id";
   private static final String STORE_PROTOCOL = "store_protocol";
@@ -127,13 +124,10 @@ private HttpGet createGetRequest(String url) {
   }
 
   private String urlParameters(long lastTransactionId, long lastAclChangesetId, AlfrescoFilters filters) {
-    String urlParameters = String.format("%s=%d&%s=%d&%s=%s&%s=%s&%s=%s&%s=%s",
+    String urlParameters = String.format("%s=%d&%s=%d&%s=%s",
     		URL_PARAM_LAST_TXN_ID, lastTransactionId,
     		URL_PARAM_LAST_ACL_CS_ID, lastAclChangesetId,
-    		URL_PARAM_SITES_FILTER, gson.toJson(filters.getSiteFilters()),
-    		URL_PARAM_MIMETYPES_FILTER, gson.toJson(filters.getMimetypeFilters()),
-    		URL_PARAM_ASPECTS_FILTER, gson.toJson(filters.getAspectFilters()),
-    		URL_PARAM_METADATA_FILTER, gson.toJson(filters.getMetadataFilters()));
+    		URL_PARAM_INDEXING_FILTERS, filters.toJSONString());
     try {
 		return URLEncoder.encode(urlParameters, "UTF-8");
 	} catch (UnsupportedEncodingException e) {

--- a/alfresco-indexer-client/src/main/java/org/alfresco/consulting/indexer/client/WebScriptsAlfrescoClient.java
+++ b/alfresco-indexer-client/src/main/java/org/alfresco/consulting/indexer/client/WebScriptsAlfrescoClient.java
@@ -124,15 +124,24 @@ private HttpGet createGetRequest(String url) {
   }
 
   private String urlParameters(long lastTransactionId, long lastAclChangesetId, AlfrescoFilters filters) {
-    String urlParameters = String.format("%s=%d&%s=%d&%s=%s",
+    
+      
+      String indexingFilters=null;
+      try
+      {
+          indexingFilters = URLEncoder.encode(filters.toJSONString(),"UTF-8");
+      }
+      catch (UnsupportedEncodingException e)
+      {
+          indexingFilters= filters.toJSONString();
+      }
+      
+      String urlParameters = String.format("%s=%d&%s=%d&%s=%s",
     		URL_PARAM_LAST_TXN_ID, lastTransactionId,
     		URL_PARAM_LAST_ACL_CS_ID, lastAclChangesetId,
-    		URL_PARAM_INDEXING_FILTERS, filters.toJSONString());
-    try {
-		return URLEncoder.encode(urlParameters, "UTF-8");
-	} catch (UnsupportedEncodingException e) {
+    		URL_PARAM_INDEXING_FILTERS, indexingFilters);
+
 		return urlParameters;
-	}
   }
 
   private AlfrescoResponse fromHttpEntity(HttpEntity entity) throws IOException {

--- a/alfresco-indexer-client/src/main/java/org/alfresco/consulting/indexer/client/WebScriptsAlfrescoClient.java
+++ b/alfresco-indexer-client/src/main/java/org/alfresco/consulting/indexer/client/WebScriptsAlfrescoClient.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.codec.net.URLCodec;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.CloseableHttpResponse;

--- a/alfresco-indexer-client/src/test/java/org/alfresco/consulting/indexer/client/AlfrescoClientTest.java
+++ b/alfresco-indexer-client/src/test/java/org/alfresco/consulting/indexer/client/AlfrescoClientTest.java
@@ -79,7 +79,7 @@ public class AlfrescoClientTest {
         "\"last_txn_id\": 2," +
         "\"last_acl_changeset_id\": 2  } ");
 
-    AlfrescoResponse response = client.fetchNodes(0, 0);
+    AlfrescoResponse response = client.fetchNodes(0, 0, new AlfrescoFilters());
     List<Map<String, Object>> list = response.getDocumentList();
 
     Assert.assertEquals(1, list.size());
@@ -110,7 +110,7 @@ public class AlfrescoClientTest {
         "\"last_txn_id\": 2," +
         "\"last_acl_changeset_id\": 2  } ");
 
-    AlfrescoResponse response = client.fetchNodes(0, 0);
+    AlfrescoResponse response = client.fetchNodes(0, 0, new AlfrescoFilters());
     List<Map<String, Object>> list = response.getDocumentList();
 
     Assert.assertEquals(1, list.size());
@@ -131,7 +131,7 @@ public class AlfrescoClientTest {
         "\"last_txn_id\": 0," +
         "\"last_acl_changeset_id\": 0  } ");
 
-    AlfrescoResponse response = client.fetchNodes(0, 0);
+    AlfrescoResponse response = client.fetchNodes(0, 0, new AlfrescoFilters());
     assertTrue(response.getDocumentList().isEmpty());
   }
 
@@ -142,7 +142,7 @@ public class AlfrescoClientTest {
 
     long lastTransactionId = 0;
     long lastAclChangesetId = 0;
-    client.fetchNodes(lastTransactionId, 0);
+    client.fetchNodes(lastTransactionId, 0, new AlfrescoFilters());
     List<LoggedRequest> requests = WireMock.findAll(
         getRequestedFor(urlMatching(changesEndpoint)));
 
@@ -155,7 +155,7 @@ public class AlfrescoClientTest {
   public void whenAlfrescoIsDownAnExceptionShouldBeThrown() throws Exception {
     stubFor(get(urlMatching(changesEndpoint)).willReturn(aResponse().withFault(Fault.EMPTY_RESPONSE)));
 
-    AlfrescoResponse alfrescoResponse = client.fetchNodes(0, 0);
+    AlfrescoResponse alfrescoResponse = client.fetchNodes(0, 0, new AlfrescoFilters());
 
     assertNotNull("Response should never be null", alfrescoResponse);
   }
@@ -263,7 +263,7 @@ public class AlfrescoClientTest {
                 "\"last_acl_changeset_id\": 2 } ")));
 
     client = new WebScriptsAlfrescoClient("http", "localhost:8089", "/alfresco/service", STORE_PROTOCOL, STORE_ID, "username", "password");
-    AlfrescoResponse response = client.fetchNodes(0, 0);
+    AlfrescoResponse response = client.fetchNodes(0, 0, new AlfrescoFilters());
     List<Map<String, Object>> list = response.getDocumentList();
 
     Assert.assertEquals(1, list.size());

--- a/alfresco-indexer-webscripts/src/main/amp/config/alfresco/extension/templates/webscripts/org/alfresco/consulting/indexer/webscripts/changes.get.desc.xml
+++ b/alfresco-indexer-webscripts/src/main/amp/config/alfresco/extension/templates/webscripts/org/alfresco/consulting/indexer/webscripts/changes.get.desc.xml
@@ -1,7 +1,7 @@
 <webscript>
   <shortname>Node Changes</shortname>
   <description>Node Changes</description>
-  <url>/node/changes/{storeProtocol}/{storeId}?lastTxnId={lastTxnId?}&amp;lastAclChangesetId=${lastAclChangesetId}&amp;maxTxns=${maxTxns?}&amp;maxAclChangesets=${maxAclChangesets?}</url>
+  <url>/node/changes/{storeProtocol}/{storeId}?lastTxnId={lastTxnId?}&amp;lastAclChangesetId=${lastAclChangesetId}&amp;indexingFilters=${indexingFilters?}&amp;maxTxns=${maxTxns?}&amp;maxAclChangesets=${maxAclChangesets?}</url>
   <authentication>user</authentication>
   <format default="json">argument</format>
   <family>Custom Indexer</family>

--- a/alfresco-indexer-webscripts/src/main/amp/config/alfresco/extension/templates/webscripts/org/alfresco/consulting/indexer/webscripts/changes.get.json.ftl
+++ b/alfresco-indexer-webscripts/src/main/amp/config/alfresco/extension/templates/webscripts/org/alfresco/consulting/indexer/webscripts/changes.get.json.ftl
@@ -1,6 +1,6 @@
 {
   <#if nodes??>"totalNodes" : "${nodes?size}",</#if> 
-  <#if time??>"elapsedTime" : "${elapsedTime}",</#if>
+  <#if elapsedTime??>"elapsedTime" : "${elapsedTime}",</#if>
   "docs" : [
     <#list nodes as node>
       {

--- a/alfresco-indexer-webscripts/src/main/amp/config/alfresco/extension/templates/webscripts/org/alfresco/consulting/indexer/webscripts/changes.get.json.ftl
+++ b/alfresco-indexer-webscripts/src/main/amp/config/alfresco/extension/templates/webscripts/org/alfresco/consulting/indexer/webscripts/changes.get.json.ftl
@@ -1,4 +1,6 @@
 {
+  <#if nodes??>"totalNodes" : "${nodes?size}",</#if> 
+  <#if time??>"elapsedTime" : "${elapsedTime}",</#if>
   "docs" : [
     <#list nodes as node>
       {

--- a/alfresco-indexer-webscripts/src/main/amp/config/alfresco/ibatis/org.hibernate.dialect.Dialect/indexing-SqlMap.xml
+++ b/alfresco-indexer-webscripts/src/main/amp/config/alfresco/ibatis/org.hibernate.dialect.Dialect/indexing-SqlMap.xml
@@ -35,58 +35,44 @@
     join alf_qname q on q.id=n.type_qname_id
 	join alf_namespace ns on ns.id=q.ns_id
 	
-	<!-- Join properties -->
-<!-- 	<if test="properties != null and properties.size() > 0"> -->
-<!-- 		join alf_node_properties pr on pr.node_id=n.id -->
-<!-- 		join alf_qname qp on qp.id=pr.qname_id -->
-<!-- 		join alf_namespace nsp on nsp.id=qp.ns_id -->
-<!-- 	</if> -->
+	<!-- Filter by node types --> 
+	<if test="allowedTypes != null and allowedTypes.size() > 0">
+		and
+		('{' || ns.uri || '}' || q.local_name) in
+  		<foreach item="type" index="index" collection="allowedTypes" open="(" separator="," close=")">
+ 			#{type}
+   		</foreach>
+	</if>
 	
+	<!-- Filter by mimetypes --> 
+	<if test="mimeTypes != null and mimeTypes.size() > 0">
+		join alf_qname qm on qm.id=n.type_qname_id
+		join alf_node_properties pm on pm.node_id=n.id and pm.qname_id=qm.id
+		join alf_content_data dm on dm.id=pm.long_value
+		join alf_mimetype m on dm.content_mimetype_id = m.id and m.mimetype_str in 
+		<foreach item="mime" index="index" collection="mimeTypes" open="(" separator="," close=")">
+       		#{mime}
+     	</foreach>
+    </if>
+		    
+	where
 	<!-- Filter by aspects --> 
 	<if test="aspects != null and aspects.size() > 0">
-	and n.id in
-	(
-		SELECT n.id FROM alf_node n
-			<foreach item="aspect" index="index" collection="aspects" open="" separator="" close="">
-				JOIN alf_node_aspects a${index} ON a${index}.node_id = n.id
-				JOIN alf_qname q${index} ON q${index}.id = a${index}.qname_id 
-				JOIN alf_namespace ns${index} ON ns${index}.id = q${index}.ns_id
-            </foreach>
-		WHERE  
-			<foreach item="aspect" index="index" collection="aspects" open="(" separator=" AND " close=")">
-				('{' || ns${index}.uri || '}' || q${index}.local_name) = #{aspect}
-			</foreach> 
-	)
-	</if>
-	where
-	<if test="(allowedTypes!= null and allowedTypes.size() > 0)|| (mimeTypes!= null and mimeTypes.size() > 0)">
-		n.id in 
+		n.id in
 		(
-			select n.id from alf_node n
-			join alf_qname q on q.id=n.type_qname_id
-			join alf_namespace ns on ns.id=q.ns_id
-			join alf_node_properties p on p.node_id=n.id
-			join alf_content_data d on d.id=p.long_value
-			join alf_content_url u on u.id=d.content_url_id 
-			
-			<!-- Filter by mimetypes --> 
-			<if test="mimeTypes != null and mimeTypes.size() > 0">
-				join alf_mimetype m on d.content_mimetype_id = m.id and m.mimetype_str in 
-				<foreach item="mime" index="index" collection="mimeTypes" open="(" separator="," close=")">
-		        		#{mime}
-		      	</foreach>
-		    </if>
-		    
-		    <!-- Filter by node types --> 
-		    <if test="allowedTypes != null and allowedTypes.size() > 0">
-				where
-				('{' || ns.uri || '}' || q.local_name) in
-      			<foreach item="type" index="index" collection="allowedTypes" open="(" separator="," close=")">
-        			#{type}
-      			</foreach>
-			</if>
+			SELECT n.id FROM alf_node n
+				<foreach item="aspect" index="index" collection="aspects" open="" separator="" close="">
+					JOIN alf_node_aspects a${index} ON a${index}.node_id = n.id
+					JOIN alf_qname q${index} ON q${index}.id = a${index}.qname_id 
+					JOIN alf_namespace ns${index} ON ns${index}.id = q${index}.ns_id
+            	</foreach>
+			WHERE  
+				<foreach item="aspect" index="index" collection="aspects" open="(" separator=" AND " close=")">
+					('{' || ns${index}.uri || '}' || q${index}.local_name) = #{aspect}
+				</foreach> 
 		) and
-	</if>
+	</if>	
+
 	
 	<!-- Filter by name extension -->
 	<if test="excludedNameExtension != null and excludedNameExtension.size() > 0">
@@ -102,37 +88,6 @@
 		) and
 	</if>
 	
-	<!-- Filter by properties --> 
-<!-- 	<if test="properties != null and properties.size() > 0"> -->
-<!-- 	( -->
-		<!-- Boolean value -->
-<!-- 		(('{' || nsp.uri || '}' || qp.local_name || ':' || pr.boolean_value) in -->
-<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
-<!--         	#{prop} -->
-<!--       	</foreach> and pr.persisted_type_n=1) or -->
-<!--       	Long value -->
-<!--       	(('{' || nsp.uri || '}' || qp.local_name || ':' || pr.long_value) in -->
-<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
-<!--         	#{prop} -->
-<!--       	</foreach> and pr.persisted_type_n=3) or -->
-<!--       	Float value -->
-<!--       	(('{' || nsp.uri || '}' || qp.local_name || ':' || pr.float_value) in -->
-<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
-<!--         	#{prop} -->
-<!--       	</foreach> and pr.persisted_type_n=4) or -->
-<!--       	Double value -->
-<!--       	(('{' || nsp.uri || '}' || qp.local_name || ':' || pr.double_value) in -->
-<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
-<!--         	#{prop} -->
-<!--       	</foreach> and pr.persisted_type_n=5) or -->
-<!--       	String value -->
-<!--       	(('{' || nsp.uri || '}' || qp.local_name || ':' || pr.string_value) in -->
-<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
-<!--         	#{prop} -->
-<!--       	</foreach> and pr.persisted_type_n=6) -->
-<!--     ) and -->
-<!-- 	</if> -->
-	
 	n.store_id = #{storeId} and
     acl.acl_change_set &gt; #{minId} and
     acl.acl_change_set &lt;= #{maxId}
@@ -140,7 +95,7 @@
   </select>
 
   <select id="select_NodeIndexesByTransactionId" parameterType="NodeIndexLoad" resultMap="result_NodeIndex">
-    select 
+	select 
     n.id 				as id,
     n.uuid 				as uuid, 
     n.version 			as version, 
@@ -156,56 +111,42 @@
     join alf_qname q on q.id=n.type_qname_id
 	join alf_namespace ns on ns.id=q.ns_id
 	
-	<!-- Join properties -->
-<!-- 	<if test="properties != null and properties.size() > 0"> -->
-<!-- 		join alf_node_properties pr on pr.node_id=n.id -->
-<!-- 		join alf_qname qp on qp.id=pr.qname_id -->
-<!-- 		join alf_namespace nsp on nsp.id=qp.ns_id -->
-<!-- 	</if> -->
+	<!-- Filter by node types --> 
+	<if test="allowedTypes != null and allowedTypes.size() > 0">
+		and
+		('{' || ns.uri || '}' || q.local_name) in
+  		<foreach item="type" index="index" collection="allowedTypes" open="(" separator="," close=")">
+ 			#{type}
+   		</foreach>
+	</if>
+	
+	<!-- Filter by mimetypes --> 
+	<if test="mimeTypes != null and mimeTypes.size() > 0">
+		join alf_qname qm on qm.id=n.type_qname_id
+		join alf_node_properties pm on pm.node_id=n.id and pm.qname_id=qm.id
+		join alf_content_data dm on dm.id=pm.long_value
+		join alf_mimetype m on dm.content_mimetype_id = m.id and m.mimetype_str in 
+		<foreach item="mime" index="index" collection="mimeTypes" open="(" separator="," close=")">
+       		#{mime}
+     	</foreach>
+    </if>	
+    
+	where
 	
 	<!-- Filter by aspects --> 
 	<if test="aspects != null and aspects.size() > 0">
-	and n.id in
-	(
-		SELECT n.id FROM alf_node n
-			<foreach item="aspect" index="index" collection="aspects" open="" separator="" close="">
-				JOIN alf_node_aspects a${index} ON a${index}.node_id = n.id
-				JOIN alf_qname q${index} ON q${index}.id = a${index}.qname_id 
-				JOIN alf_namespace ns${index} ON ns${index}.id = q${index}.ns_id
-            </foreach>
-		WHERE  
-			<foreach item="aspect" index="index" collection="aspects" open="(" separator=" AND " close=")">
-				('{' || ns${index}.uri || '}' || q${index}.local_name) = #{aspect}
-			</foreach> 
-	)
-	</if>
-	where
-	<if test="(allowedTypes!= null and allowedTypes.size() > 0)|| (mimeTypes!= null and mimeTypes.size() > 0)">
-		n.id in 
+		n.id in
 		(
-			select n.id from alf_node n
-			join alf_qname q on q.id=n.type_qname_id
-			join alf_namespace ns on ns.id=q.ns_id
-			join alf_node_properties p on p.node_id=n.id
-			join alf_content_data d on d.id=p.long_value
-			join alf_content_url u on u.id=d.content_url_id 
-			
-			<!-- Filter by mimetypes --> 
-			<if test="mimeTypes != null and mimeTypes.size() > 0">
-				join alf_mimetype m on d.content_mimetype_id = m.id and m.mimetype_str in 
-				<foreach item="mime" index="index" collection="mimeTypes" open="(" separator="," close=")">
-		        		#{mime}
-		      	</foreach>
-		    </if>
-		    
-		    <!-- Filter by node types --> 
-		    <if test="allowedTypes != null and allowedTypes.size() > 0">
-				where
-				('{' || ns.uri || '}' || q.local_name) in
-      			<foreach item="type" index="index" collection="allowedTypes" open="(" separator="," close=")">
-        			#{type}
-      			</foreach>
-			</if>
+			SELECT n.id FROM alf_node n
+				<foreach item="aspect" index="index" collection="aspects" open="" separator="" close="">
+					JOIN alf_node_aspects a${index} ON a${index}.node_id = n.id
+					JOIN alf_qname q${index} ON q${index}.id = a${index}.qname_id 
+					JOIN alf_namespace ns${index} ON ns${index}.id = q${index}.ns_id
+            	</foreach>
+			WHERE  
+				<foreach item="aspect" index="index" collection="aspects" open="(" separator=" AND " close=")">
+					('{' || ns${index}.uri || '}' || q${index}.local_name) = #{aspect}
+				</foreach> 
 		) and
 	</if>
 	
@@ -222,37 +163,6 @@
 			</foreach>
 		) and
 	</if>
-	
-	<!-- Filter by properties --> 
-<!-- 	<if test="properties != null and properties.size() > 0"> -->
-<!-- 	( -->
-		<!-- Boolean value -->
-<!-- 		(('{' || nsp.uri || '}' || qp.local_name || ':' || pr.boolean_value) in -->
-<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
-<!--         	#{prop} -->
-<!--       	</foreach> and pr.persisted_type_n=1) or -->
-<!--       	Long value -->
-<!--       	(('{' || nsp.uri || '}' || qp.local_name || ':' || pr.long_value) in -->
-<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
-<!--         	#{prop} -->
-<!--       	</foreach> and pr.persisted_type_n=3) or -->
-<!--       	Float value -->
-<!--       	(('{' || nsp.uri || '}' || qp.local_name || ':' || pr.float_value) in -->
-<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
-<!--         	#{prop} -->
-<!--       	</foreach> and pr.persisted_type_n=4) or -->
-<!--       	Double value -->
-<!--       	(('{' || nsp.uri || '}' || qp.local_name || ':' || pr.double_value) in -->
-<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
-<!--         	#{prop} -->
-<!--       	</foreach> and pr.persisted_type_n=5) or -->
-<!--       	String value -->
-<!--       	(('{' || nsp.uri || '}' || qp.local_name || ':' || pr.string_value) in -->
-<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
-<!--         	#{prop} -->
-<!--       	</foreach> and pr.persisted_type_n=6) -->
-<!--     ) and -->
-<!-- 	</if> -->
 	
 	n.store_id = #{storeId} and
 	n.transaction_id &gt; #{minId} and

--- a/alfresco-indexer-webscripts/src/main/amp/config/alfresco/ibatis/org.hibernate.dialect.Dialect/indexing-SqlMap.xml
+++ b/alfresco-indexer-webscripts/src/main/amp/config/alfresco/ibatis/org.hibernate.dialect.Dialect/indexing-SqlMap.xml
@@ -192,4 +192,21 @@
     where
     node.uuid = #{uuid}
   </select>
+  
+  <select id="select_LastTransactionID" resultType="long">
+	select 
+	id 
+	from alf_transaction 
+	order by id desc 
+	limit 1
+  </select>
+  
+  <select id="select_LastAclChangeSetID" resultType="long">
+	select 
+	id 
+	from alf_acl_change_set
+	order by id desc 
+	limit 1
+  </select>
+  
 </mapper>

--- a/alfresco-indexer-webscripts/src/main/amp/config/alfresco/ibatis/org.hibernate.dialect.Dialect/indexing-SqlMap.xml
+++ b/alfresco-indexer-webscripts/src/main/amp/config/alfresco/ibatis/org.hibernate.dialect.Dialect/indexing-SqlMap.xml
@@ -18,29 +18,79 @@
   </resultMap>
 
   <select id="select_NodeIndexesByAclChangesetId" parameterType="NodeIndexLoad" resultMap="result_NodeIndex">
-    select
-    node.id                 as id,
-    node.uuid               as uuid,
-    node.version            as version,
-    node.store_id           as store_id,
+    select 
+    n.id 				as id,
+    n.uuid 				as uuid, 
+    n.version 			as version, 
+    n.store_id 			as store_id, 
     #{storeProtocol}             as protocol,
     #{storeIdentifier}           as identifier,
-    qname.local_name        as type_name,
-    ns.uri                  as type_namespace,
-    acl.acl_change_set      as acl_changeset_id
-    from alf_node node
-    left outer join alf_access_control_list acl on node.acl_id = acl.id
-    left outer join alf_qname qname on node.type_qname_id = qname.id
-    left outer join alf_namespace ns on qname.ns_id = ns.id
-    where
-    <if test="allowedTypes != null">
-      ('{' || ns.uri || '}' || qname.local_name) in
-      <foreach item="item" index="index" collection="allowedTypes" open="(" separator="," close=")">
-        #{item}
-      </foreach> and
-    </if>
-    <if test="excludedNameExtension != null">
-    	node.id not in
+    q.local_name 		as type_name, 
+    ns.uri 				as type_namespace, 
+    acl.acl_change_set  as acl_changeset_id
+    from 
+    alf_node n
+    
+    left outer join alf_access_control_list acl on n.acl_id = acl.id
+    join alf_qname q on q.id=n.type_qname_id
+	join alf_namespace ns on ns.id=q.ns_id
+	
+	<!-- Join properties -->
+<!-- 	<if test="properties != null and properties.size() > 0"> -->
+<!-- 		join alf_node_properties pr on pr.node_id=n.id -->
+<!-- 		join alf_qname qp on qp.id=pr.qname_id -->
+<!-- 		join alf_namespace nsp on nsp.id=qp.ns_id -->
+<!-- 	</if> -->
+	
+	<!-- Filter by aspects --> 
+	<if test="aspects != null and aspects.size() > 0">
+	and n.id in
+	(
+		SELECT n.id FROM alf_node n
+			<foreach item="aspect" index="index" collection="aspects" open="" separator="" close="">
+				JOIN alf_node_aspects a${index} ON a${index}.node_id = n.id
+				JOIN alf_qname q${index} ON q${index}.id = a${index}.qname_id 
+				JOIN alf_namespace ns${index} ON ns${index}.id = q${index}.ns_id
+            </foreach>
+		WHERE  
+			<foreach item="aspect" index="index" collection="aspects" open="(" separator=" AND " close=")">
+				('{' || ns${index}.uri || '}' || q${index}.local_name) = #{aspect}
+			</foreach> 
+	)
+	</if>
+	where
+	<if test="(allowedTypes!= null and allowedTypes.size() > 0)|| (mimeTypes!= null and mimeTypes.size() > 0)">
+		n.id in 
+		(
+			select n.id from alf_node n
+			join alf_qname q on q.id=n.type_qname_id
+			join alf_namespace ns on ns.id=q.ns_id
+			join alf_node_properties p on p.node_id=n.id
+			join alf_content_data d on d.id=p.long_value
+			join alf_content_url u on u.id=d.content_url_id 
+			
+			<!-- Filter by mimetypes --> 
+			<if test="mimeTypes != null and mimeTypes.size() > 0">
+				join alf_mimetype m on d.content_mimetype_id = m.id and m.mimetype_str in 
+				<foreach item="mime" index="index" collection="mimeTypes" open="(" separator="," close=")">
+		        		#{mime}
+		      	</foreach>
+		    </if>
+		    
+		    <!-- Filter by node types --> 
+		    <if test="allowedTypes != null and allowedTypes.size() > 0">
+				where
+				('{' || ns.uri || '}' || q.local_name) in
+      			<foreach item="type" index="index" collection="allowedTypes" open="(" separator="," close=")">
+        			#{type}
+      			</foreach>
+			</if>
+		) and
+	</if>
+	
+	<!-- Filter by name extension -->
+	<if test="excludedNameExtension != null and excludedNameExtension.size() > 0">
+    	n.id not in
 		(
 			select n.id from alf_node n
 			join alf_node_properties np on np.node_id=n.id
@@ -51,41 +101,117 @@
 			</foreach>
 		) and
 	</if>
-    node.store_id = #{storeId} and
+	
+	<!-- Filter by properties --> 
+<!-- 	<if test="properties != null and properties.size() > 0"> -->
+<!-- 	( -->
+		<!-- Boolean value -->
+<!-- 		(('{' || nsp.uri || '}' || qp.local_name || ':' || pr.boolean_value) in -->
+<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
+<!--         	#{prop} -->
+<!--       	</foreach> and pr.persisted_type_n=1) or -->
+<!--       	Long value -->
+<!--       	(('{' || nsp.uri || '}' || qp.local_name || ':' || pr.long_value) in -->
+<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
+<!--         	#{prop} -->
+<!--       	</foreach> and pr.persisted_type_n=3) or -->
+<!--       	Float value -->
+<!--       	(('{' || nsp.uri || '}' || qp.local_name || ':' || pr.float_value) in -->
+<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
+<!--         	#{prop} -->
+<!--       	</foreach> and pr.persisted_type_n=4) or -->
+<!--       	Double value -->
+<!--       	(('{' || nsp.uri || '}' || qp.local_name || ':' || pr.double_value) in -->
+<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
+<!--         	#{prop} -->
+<!--       	</foreach> and pr.persisted_type_n=5) or -->
+<!--       	String value -->
+<!--       	(('{' || nsp.uri || '}' || qp.local_name || ':' || pr.string_value) in -->
+<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
+<!--         	#{prop} -->
+<!--       	</foreach> and pr.persisted_type_n=6) -->
+<!--     ) and -->
+<!-- 	</if> -->
+	
+	n.store_id = #{storeId} and
     acl.acl_change_set &gt; #{minId} and
     acl.acl_change_set &lt;= #{maxId}
-    order by
-    acl.acl_change_set ASC
+	order by n.transaction_id ASC
   </select>
 
-  <!--"#{storeId}"            as store_id,-->
-  <!--"#{storeProtocol}"      as protocol,-->
-  <!--"#{storeIdentifier}"    as identifier,-->
-
-
   <select id="select_NodeIndexesByTransactionId" parameterType="NodeIndexLoad" resultMap="result_NodeIndex">
-    select
-    node.id                 as id,
-    node.uuid               as uuid,
-    node.version            as version,
-    node.store_id           as store_id,
+    select 
+    n.id 				as id,
+    n.uuid 				as uuid, 
+    n.version 			as version, 
+    n.store_id 			as store_id, 
     #{storeProtocol}             as protocol,
     #{storeIdentifier}           as identifier,
-    qname.local_name        as type_name,
-    ns.uri                  as type_namespace,
-    node.transaction_id     as txn_id
-    from alf_node node
-    left outer join alf_qname qname on node.type_qname_id = qname.id
-    left outer join alf_namespace ns on qname.ns_id = ns.id
-    where
-    <if test="allowedTypes != null">
-      ('{' || ns.uri || '}' || qname.local_name) in
-      <foreach item="item" index="index" collection="allowedTypes" open="(" separator="," close=")">
-        #{item}
-      </foreach> and
-    </if>
-    <if test="excludedNameExtension != null">
-    	node.id not in
+    q.local_name 		as type_name, 
+    ns.uri 				as type_namespace, 
+    n.transaction_id 	as txn_id
+    from 
+    alf_node n
+    
+    join alf_qname q on q.id=n.type_qname_id
+	join alf_namespace ns on ns.id=q.ns_id
+	
+	<!-- Join properties -->
+<!-- 	<if test="properties != null and properties.size() > 0"> -->
+<!-- 		join alf_node_properties pr on pr.node_id=n.id -->
+<!-- 		join alf_qname qp on qp.id=pr.qname_id -->
+<!-- 		join alf_namespace nsp on nsp.id=qp.ns_id -->
+<!-- 	</if> -->
+	
+	<!-- Filter by aspects --> 
+	<if test="aspects != null and aspects.size() > 0">
+	and n.id in
+	(
+		SELECT n.id FROM alf_node n
+			<foreach item="aspect" index="index" collection="aspects" open="" separator="" close="">
+				JOIN alf_node_aspects a${index} ON a${index}.node_id = n.id
+				JOIN alf_qname q${index} ON q${index}.id = a${index}.qname_id 
+				JOIN alf_namespace ns${index} ON ns${index}.id = q${index}.ns_id
+            </foreach>
+		WHERE  
+			<foreach item="aspect" index="index" collection="aspects" open="(" separator=" AND " close=")">
+				('{' || ns${index}.uri || '}' || q${index}.local_name) = #{aspect}
+			</foreach> 
+	)
+	</if>
+	where
+	<if test="(allowedTypes!= null and allowedTypes.size() > 0)|| (mimeTypes!= null and mimeTypes.size() > 0)">
+		n.id in 
+		(
+			select n.id from alf_node n
+			join alf_qname q on q.id=n.type_qname_id
+			join alf_namespace ns on ns.id=q.ns_id
+			join alf_node_properties p on p.node_id=n.id
+			join alf_content_data d on d.id=p.long_value
+			join alf_content_url u on u.id=d.content_url_id 
+			
+			<!-- Filter by mimetypes --> 
+			<if test="mimeTypes != null and mimeTypes.size() > 0">
+				join alf_mimetype m on d.content_mimetype_id = m.id and m.mimetype_str in 
+				<foreach item="mime" index="index" collection="mimeTypes" open="(" separator="," close=")">
+		        		#{mime}
+		      	</foreach>
+		    </if>
+		    
+		    <!-- Filter by node types --> 
+		    <if test="allowedTypes != null and allowedTypes.size() > 0">
+				where
+				('{' || ns.uri || '}' || q.local_name) in
+      			<foreach item="type" index="index" collection="allowedTypes" open="(" separator="," close=")">
+        			#{type}
+      			</foreach>
+			</if>
+		) and
+	</if>
+	
+	<!-- Filter by name extension -->
+	<if test="excludedNameExtension != null and excludedNameExtension.size() > 0">
+    	n.id not in
 		(
 			select n.id from alf_node n
 			join alf_node_properties np on np.node_id=n.id
@@ -96,11 +222,42 @@
 			</foreach>
 		) and
 	</if>
-	node.store_id = #{storeId} and
-    node.transaction_id &gt; #{minId} and
-    node.transaction_id &lt;= #{maxId}
-    order by
-    node.transaction_id ASC
+	
+	<!-- Filter by properties --> 
+<!-- 	<if test="properties != null and properties.size() > 0"> -->
+<!-- 	( -->
+		<!-- Boolean value -->
+<!-- 		(('{' || nsp.uri || '}' || qp.local_name || ':' || pr.boolean_value) in -->
+<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
+<!--         	#{prop} -->
+<!--       	</foreach> and pr.persisted_type_n=1) or -->
+<!--       	Long value -->
+<!--       	(('{' || nsp.uri || '}' || qp.local_name || ':' || pr.long_value) in -->
+<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
+<!--         	#{prop} -->
+<!--       	</foreach> and pr.persisted_type_n=3) or -->
+<!--       	Float value -->
+<!--       	(('{' || nsp.uri || '}' || qp.local_name || ':' || pr.float_value) in -->
+<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
+<!--         	#{prop} -->
+<!--       	</foreach> and pr.persisted_type_n=4) or -->
+<!--       	Double value -->
+<!--       	(('{' || nsp.uri || '}' || qp.local_name || ':' || pr.double_value) in -->
+<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
+<!--         	#{prop} -->
+<!--       	</foreach> and pr.persisted_type_n=5) or -->
+<!--       	String value -->
+<!--       	(('{' || nsp.uri || '}' || qp.local_name || ':' || pr.string_value) in -->
+<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
+<!--         	#{prop} -->
+<!--       	</foreach> and pr.persisted_type_n=6) -->
+<!--     ) and -->
+<!-- 	</if> -->
+	
+	n.store_id = #{storeId} and
+	n.transaction_id &gt; #{minId} and
+    n.transaction_id &lt;= #{maxId}
+	order by n.transaction_id ASC
   </select>
   
   <select id="select_NodeIndexesByUuid" parameterType="NodeIndexLoad" resultMap="result_NodeIndex">

--- a/alfresco-indexer-webscripts/src/main/amp/config/alfresco/ibatis/org.hibernate.dialect.MySQLInnoDBDialect/indexing-SqlMap.xml
+++ b/alfresco-indexer-webscripts/src/main/amp/config/alfresco/ibatis/org.hibernate.dialect.MySQLInnoDBDialect/indexing-SqlMap.xml
@@ -34,56 +34,42 @@
     join alf_qname q on q.id=n.type_qname_id
 	join alf_namespace ns on ns.id=q.ns_id
 	
-	<!-- Join properties -->
-<!-- 	<if test="properties != null and properties.size() > 0"> -->
-<!-- 		join alf_node_properties pr on pr.node_id=n.id -->
-<!-- 		join alf_qname qp on qp.id=pr.qname_id -->
-<!-- 		join alf_namespace nsp on nsp.id=qp.ns_id -->
-<!-- 	</if> -->
+	<!-- Filter by node types --> 
+	<if test="allowedTypes != null and allowedTypes.size() > 0">
+		and
+		concat('{', ns.uri, '}', q.local_name) in
+  		<foreach item="type" index="index" collection="allowedTypes" open="(" separator="," close=")">
+ 			#{type}
+   		</foreach>
+	</if>
+	
+	<!-- Filter by mimetypes --> 
+	<if test="mimeTypes != null and mimeTypes.size() > 0">
+		join alf_qname qm on qm.id=n.type_qname_id
+		join alf_node_properties pm on pm.node_id=n.id and pm.qname_id=qm.id
+		join alf_content_data dm on dm.id=pm.long_value
+		join alf_mimetype m on dm.content_mimetype_id = m.id and m.mimetype_str in 
+		<foreach item="mime" index="index" collection="mimeTypes" open="(" separator="," close=")">
+       		#{mime}
+     	</foreach>
+    </if>	
+    
+	where
 	
 	<!-- Filter by aspects --> 
 	<if test="aspects != null and aspects.size() > 0">
-	and n.id in
-	(
-		SELECT n.id FROM alf_node n
+		n.id in
+		(
+			SELECT n.id FROM alf_node n
 			<foreach item="aspect" index="index" collection="aspects" open="" separator="" close="">
 				JOIN alf_node_aspects a${index} ON a${index}.node_id = n.id
 				JOIN alf_qname q${index} ON q${index}.id = a${index}.qname_id 
 				JOIN alf_namespace ns${index} ON ns${index}.id = q${index}.ns_id
             </foreach>
-		WHERE  
-			<foreach item="aspect" index="index" collection="aspects" open="(" separator=" AND " close=")">
-				('{' || ns${index}.uri || '}' || q${index}.local_name) = #{aspect}
-			</foreach> 
-	)
-	</if>
-	where
-	<if test="(allowedTypes!= null and allowedTypes.size() > 0)|| (mimeTypes!= null and mimeTypes.size() > 0)">
-		n.id in 
-		(
-			select n.id from alf_node n
-			join alf_qname q on q.id=n.type_qname_id
-			join alf_namespace ns on ns.id=q.ns_id
-			join alf_node_properties p on p.node_id=n.id
-			join alf_content_data d on d.id=p.long_value
-			join alf_content_url u on u.id=d.content_url_id 
-			
-			<!-- Filter by mimetypes --> 
-			<if test="mimeTypes != null and mimeTypes.size() > 0">
-				join alf_mimetype m on d.content_mimetype_id = m.id and m.mimetype_str in 
-				<foreach item="mime" index="index" collection="mimeTypes" open="(" separator="," close=")">
-		        		#{mime}
-		      	</foreach>
-		    </if>
-		    
-		    <!-- Filter by node types --> 
-		    <if test="allowedTypes != null and allowedTypes.size() > 0">
-				where
-				concat('{', ns.uri, '}', q.local_name) in
-      			<foreach item="type" index="index" collection="allowedTypes" open="(" separator="," close=")">
-        			#{type}
-      			</foreach>
-			</if>
+			WHERE  
+				<foreach item="aspect" index="index" collection="aspects" open="(" separator=" AND " close=")">
+					('{' || ns${index}.uri || '}' || q${index}.local_name) = #{aspect}
+				</foreach> 
 		) and
 	</if>
 	
@@ -100,37 +86,6 @@
 			</foreach>
 		) and
 	</if>
-	
-	<!-- Filter by properties --> 
-<!-- 	<if test="properties != null and properties.size() > 0"> -->
-<!-- 	( -->
-		<!-- Boolean value -->
-<!-- 		(concat('{', nsp.uri, '}', qp.local_name, ':', pr.boolean_value) in -->
-<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
-<!--         	#{prop} -->
-<!--       	</foreach> and pr.persisted_type_n=1) or -->
-<!--       	Long value -->
-<!--       	(concat('{', nsp.uri, '}', qp.local_name, ':', pr.long_value) in -->
-<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
-<!--         	#{prop} -->
-<!--       	</foreach> and pr.persisted_type_n=3) or -->
-<!--       	Float value -->
-<!--       	(concat('{', nsp.uri, '}', qp.local_name, ':', pr.float_value) in -->
-<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
-<!--         	#{prop} -->
-<!--       	</foreach> and pr.persisted_type_n=4) or -->
-<!--       	Double value -->
-<!--       	(concat('{', nsp.uri, '}', qp.local_name, ':', pr.double_value) in -->
-<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
-<!--         	#{prop} -->
-<!--       	</foreach> and pr.persisted_type_n=5) or -->
-<!--       	String value -->
-<!--       	(concat('{', nsp.uri, '}', qp.local_name, ':', pr.string_value) in -->
-<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
-<!--         	#{prop} -->
-<!--       	</foreach> and pr.persisted_type_n=6) -->
-<!--     ) and -->
-<!-- 	</if> -->
 	
 	n.store_id = #{storeId} and
     acl.acl_change_set &gt; #{minId} and
@@ -155,56 +110,42 @@
     join alf_qname q on q.id=n.type_qname_id
 	join alf_namespace ns on ns.id=q.ns_id
 	
-	<!-- Join properties -->
-<!-- 	<if test="properties != null and properties.size() > 0"> -->
-<!-- 		join alf_node_properties pr on pr.node_id=n.id -->
-<!-- 		join alf_qname qp on qp.id=pr.qname_id -->
-<!-- 		join alf_namespace nsp on nsp.id=qp.ns_id -->
-<!-- 	</if> -->
+	<!-- Filter by node types --> 
+	<if test="allowedTypes != null and allowedTypes.size() > 0">
+		and
+		concat('{', ns.uri, '}', q.local_name) in
+  		<foreach item="type" index="index" collection="allowedTypes" open="(" separator="," close=")">
+ 			#{type}
+   		</foreach>
+	</if>
+	
+	<!-- Filter by mimetypes --> 
+	<if test="mimeTypes != null and mimeTypes.size() > 0">
+		join alf_qname qm on qm.id=n.type_qname_id
+		join alf_node_properties pm on pm.node_id=n.id and pm.qname_id=qm.id
+		join alf_content_data dm on dm.id=pm.long_value
+		join alf_mimetype m on dm.content_mimetype_id = m.id and m.mimetype_str in 
+		<foreach item="mime" index="index" collection="mimeTypes" open="(" separator="," close=")">
+       		#{mime}
+     	</foreach>
+    </if>
+
+	where
 	
 	<!-- Filter by aspects --> 
 	<if test="aspects != null and aspects.size() > 0">
-	and n.id in
-	(
-		SELECT n.id FROM alf_node n
-			<foreach item="aspect" index="index" collection="aspects" open="" separator="" close="">
-				JOIN alf_node_aspects a${index} ON a${index}.node_id = n.id
-				JOIN alf_qname q${index} ON q${index}.id = a${index}.qname_id 
-				JOIN alf_namespace ns${index} ON ns${index}.id = q${index}.ns_id
-            </foreach>
-		WHERE  
-			<foreach item="aspect" index="index" collection="aspects" open="(" separator=" AND " close=")">
-				('{' || ns${index}.uri || '}' || q${index}.local_name) = #{aspect}
-			</foreach> 
-	)
-	</if>
-	where
-	<if test="(allowedTypes!= null and allowedTypes.size() > 0)|| (mimeTypes!= null and mimeTypes.size() > 0)">
-		n.id in 
+		n.id in
 		(
-			select n.id from alf_node n
-			join alf_qname q on q.id=n.type_qname_id
-			join alf_namespace ns on ns.id=q.ns_id
-			join alf_node_properties p on p.node_id=n.id
-			join alf_content_data d on d.id=p.long_value
-			join alf_content_url u on u.id=d.content_url_id 
-			
-			<!-- Filter by mimetypes --> 
-			<if test="mimeTypes != null and mimeTypes.size() > 0">
-				join alf_mimetype m on d.content_mimetype_id = m.id and m.mimetype_str in 
-				<foreach item="mime" index="index" collection="mimeTypes" open="(" separator="," close=")">
-		        		#{mime}
-		      	</foreach>
-		    </if>
-		    
-		    <!-- Filter by node types --> 
-		    <if test="allowedTypes != null and allowedTypes.size() > 0">
-				where
-				concat('{', ns.uri, '}', q.local_name) in
-      			<foreach item="type" index="index" collection="allowedTypes" open="(" separator="," close=")">
-        			#{type}
-      			</foreach>
-			</if>
+			SELECT n.id FROM alf_node n
+				<foreach item="aspect" index="index" collection="aspects" open="" separator="" close="">
+					JOIN alf_node_aspects a${index} ON a${index}.node_id = n.id
+					JOIN alf_qname q${index} ON q${index}.id = a${index}.qname_id 
+					JOIN alf_namespace ns${index} ON ns${index}.id = q${index}.ns_id
+            	</foreach>
+			WHERE  
+				<foreach item="aspect" index="index" collection="aspects" open="(" separator=" AND " close=")">
+					('{' || ns${index}.uri || '}' || q${index}.local_name) = #{aspect}
+				</foreach> 
 		) and
 	</if>
 	
@@ -221,37 +162,6 @@
 			</foreach>
 		) and
 	</if>
-	
-	<!-- Filter by properties --> 
-<!-- 	<if test="properties != null and properties.size() > 0"> -->
-<!-- 	( -->
-		<!-- Boolean value -->
-<!-- 		(concat('{', nsp.uri, '}', qp.local_name, ':', pr.boolean_value) in -->
-<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
-<!--         	#{prop} -->
-<!--       	</foreach> and pr.persisted_type_n=1) or -->
-<!--       	Long value -->
-<!--       	(concat('{', nsp.uri, '}', qp.local_name, ':', pr.long_value) in -->
-<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
-<!--         	#{prop} -->
-<!--       	</foreach> and pr.persisted_type_n=3) or -->
-<!--       	Float value -->
-<!--       	(concat('{', nsp.uri, '}', qp.local_name, ':', pr.float_value) in -->
-<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
-<!--         	#{prop} -->
-<!--       	</foreach> and pr.persisted_type_n=4) or -->
-<!--       	Double value -->
-<!--       	(concat('{', nsp.uri, '}', qp.local_name, ':', pr.double_value) in -->
-<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
-<!--         	#{prop} -->
-<!--       	</foreach> and pr.persisted_type_n=5) or -->
-<!--       	String value -->
-<!--       	(concat('{', nsp.uri, '}', qp.local_name, ':', pr.string_value) in -->
-<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
-<!--         	#{prop} -->
-<!--       	</foreach> and pr.persisted_type_n=6) -->
-<!--     ) and -->
-<!-- 	</if> -->
 	
 	n.store_id = #{storeId} and
 	n.transaction_id &gt; #{minId} and

--- a/alfresco-indexer-webscripts/src/main/amp/config/alfresco/ibatis/org.hibernate.dialect.MySQLInnoDBDialect/indexing-SqlMap.xml
+++ b/alfresco-indexer-webscripts/src/main/amp/config/alfresco/ibatis/org.hibernate.dialect.MySQLInnoDBDialect/indexing-SqlMap.xml
@@ -191,4 +191,21 @@
     where
     node.uuid = #{uuid}
   </select>
+  
+  <select id="select_LastTransactionID" resultType="long">
+	select 
+	id 
+	from alf_transaction 
+	order by id desc 
+	limit 1
+  </select>
+  
+  <select id="select_LastAclChangeSetID" resultType="long">
+	select 
+	id 
+	from alf_acl_change_set
+	order by id desc 
+	limit 1
+  </select>
+  
 </mapper>

--- a/alfresco-indexer-webscripts/src/main/amp/config/alfresco/ibatis/org.hibernate.dialect.MySQLInnoDBDialect/indexing-SqlMap.xml
+++ b/alfresco-indexer-webscripts/src/main/amp/config/alfresco/ibatis/org.hibernate.dialect.MySQLInnoDBDialect/indexing-SqlMap.xml
@@ -17,30 +17,79 @@
   </resultMap>
 
   <select id="select_NodeIndexesByAclChangesetId" parameterType="NodeIndexLoad" resultMap="result_NodeIndex">
-    select
-    node.id             as id,
-    node.uuid           as uuid,
-    node.version        as version,
-    node.store_id       as store_id,
+    select 
+    n.id 				as id,
+    n.uuid 				as uuid, 
+    n.version 			as version, 
+    n.store_id 			as store_id, 
     #{storeProtocol}             as protocol,
     #{storeIdentifier}           as identifier,
-    qname.local_name    as type_name,
-    ns.uri              as type_namespace,
+    q.local_name 		as type_name, 
+    ns.uri 				as type_namespace, 
     acl.acl_change_set  as acl_changeset_id
-    from alf_node node
-    join alf_store store on store.id = node.store_id
-    left outer join alf_access_control_list acl on node.acl_id = acl.id
-    left outer join alf_qname qname on node.type_qname_id = qname.id
-    left outer join alf_namespace ns on qname.ns_id = ns.id
-    where
-    <if test="allowedTypes != null">
-      concat('{', ns.uri, '}', qname.local_name) in
-      <foreach item="item" index="index" collection="allowedTypes" open="(" separator="," close=")">
-        #{item}
-      </foreach> and
-    </if>
-    <if test="excludedNameExtension != null">
-    	node.id not in
+    from 
+    alf_node n
+    
+    left outer join alf_access_control_list acl on n.acl_id = acl.id
+    join alf_qname q on q.id=n.type_qname_id
+	join alf_namespace ns on ns.id=q.ns_id
+	
+	<!-- Join properties -->
+<!-- 	<if test="properties != null and properties.size() > 0"> -->
+<!-- 		join alf_node_properties pr on pr.node_id=n.id -->
+<!-- 		join alf_qname qp on qp.id=pr.qname_id -->
+<!-- 		join alf_namespace nsp on nsp.id=qp.ns_id -->
+<!-- 	</if> -->
+	
+	<!-- Filter by aspects --> 
+	<if test="aspects != null and aspects.size() > 0">
+	and n.id in
+	(
+		SELECT n.id FROM alf_node n
+			<foreach item="aspect" index="index" collection="aspects" open="" separator="" close="">
+				JOIN alf_node_aspects a${index} ON a${index}.node_id = n.id
+				JOIN alf_qname q${index} ON q${index}.id = a${index}.qname_id 
+				JOIN alf_namespace ns${index} ON ns${index}.id = q${index}.ns_id
+            </foreach>
+		WHERE  
+			<foreach item="aspect" index="index" collection="aspects" open="(" separator=" AND " close=")">
+				('{' || ns${index}.uri || '}' || q${index}.local_name) = #{aspect}
+			</foreach> 
+	)
+	</if>
+	where
+	<if test="(allowedTypes!= null and allowedTypes.size() > 0)|| (mimeTypes!= null and mimeTypes.size() > 0)">
+		n.id in 
+		(
+			select n.id from alf_node n
+			join alf_qname q on q.id=n.type_qname_id
+			join alf_namespace ns on ns.id=q.ns_id
+			join alf_node_properties p on p.node_id=n.id
+			join alf_content_data d on d.id=p.long_value
+			join alf_content_url u on u.id=d.content_url_id 
+			
+			<!-- Filter by mimetypes --> 
+			<if test="mimeTypes != null and mimeTypes.size() > 0">
+				join alf_mimetype m on d.content_mimetype_id = m.id and m.mimetype_str in 
+				<foreach item="mime" index="index" collection="mimeTypes" open="(" separator="," close=")">
+		        		#{mime}
+		      	</foreach>
+		    </if>
+		    
+		    <!-- Filter by node types --> 
+		    <if test="allowedTypes != null and allowedTypes.size() > 0">
+				where
+				concat('{', ns.uri, '}', q.local_name) in
+      			<foreach item="type" index="index" collection="allowedTypes" open="(" separator="," close=")">
+        			#{type}
+      			</foreach>
+			</if>
+		) and
+	</if>
+	
+	<!-- Filter by name extension -->
+	<if test="excludedNameExtension != null and excludedNameExtension.size() > 0">
+    	n.id not in
 		(
 			select n.id from alf_node n
 			join alf_node_properties np on np.node_id=n.id
@@ -51,43 +100,117 @@
 			</foreach>
 		) and
 	</if>
-    node.store_id = #{storeId} and
+	
+	<!-- Filter by properties --> 
+<!-- 	<if test="properties != null and properties.size() > 0"> -->
+<!-- 	( -->
+		<!-- Boolean value -->
+<!-- 		(concat('{', nsp.uri, '}', qp.local_name, ':', pr.boolean_value) in -->
+<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
+<!--         	#{prop} -->
+<!--       	</foreach> and pr.persisted_type_n=1) or -->
+<!--       	Long value -->
+<!--       	(concat('{', nsp.uri, '}', qp.local_name, ':', pr.long_value) in -->
+<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
+<!--         	#{prop} -->
+<!--       	</foreach> and pr.persisted_type_n=3) or -->
+<!--       	Float value -->
+<!--       	(concat('{', nsp.uri, '}', qp.local_name, ':', pr.float_value) in -->
+<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
+<!--         	#{prop} -->
+<!--       	</foreach> and pr.persisted_type_n=4) or -->
+<!--       	Double value -->
+<!--       	(concat('{', nsp.uri, '}', qp.local_name, ':', pr.double_value) in -->
+<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
+<!--         	#{prop} -->
+<!--       	</foreach> and pr.persisted_type_n=5) or -->
+<!--       	String value -->
+<!--       	(concat('{', nsp.uri, '}', qp.local_name, ':', pr.string_value) in -->
+<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
+<!--         	#{prop} -->
+<!--       	</foreach> and pr.persisted_type_n=6) -->
+<!--     ) and -->
+<!-- 	</if> -->
+	
+	n.store_id = #{storeId} and
     acl.acl_change_set &gt; #{minId} and
     acl.acl_change_set &lt;= #{maxId}
-    order by
-    acl.acl_change_set ASC
+	order by n.transaction_id ASC
   </select>
 
   <select id="select_NodeIndexesByTransactionId" parameterType="NodeIndexLoad" resultMap="result_NodeIndex">
-    select
-    node.id             as id,
-    node.uuid           as uuid,
-    node.version        as version,
-    node.store_id       as store_id,
+    select 
+    n.id 				as id,
+    n.uuid 				as uuid, 
+    n.version 			as version, 
+    n.store_id 			as store_id, 
     #{storeProtocol}             as protocol,
     #{storeIdentifier}           as identifier,
-    qname.local_name    as type_name,
-    ns.uri              as type_namespace,
-    node.transaction_id as txn_id
-    from
-    alf_node node
-    left outer join
-    alf_qname qname
-    on
-    node.type_qname_id = qname.id
-    left outer join
-    alf_namespace ns
-    on
-    qname.ns_id = ns.id
-    where
-    <if test="allowedTypes != null">
-      concat('{', ns.uri, '}', qname.local_name) in
-      <foreach item="item" index="index" collection="allowedTypes" open="(" separator="," close=")">
-        #{item}
-      </foreach> and
-    </if>
-    <if test="excludedNameExtension != null">
-    	node.id not in
+    q.local_name 		as type_name, 
+    ns.uri 				as type_namespace, 
+    n.transaction_id 	as txn_id
+    from 
+    alf_node n
+    
+    join alf_qname q on q.id=n.type_qname_id
+	join alf_namespace ns on ns.id=q.ns_id
+	
+	<!-- Join properties -->
+<!-- 	<if test="properties != null and properties.size() > 0"> -->
+<!-- 		join alf_node_properties pr on pr.node_id=n.id -->
+<!-- 		join alf_qname qp on qp.id=pr.qname_id -->
+<!-- 		join alf_namespace nsp on nsp.id=qp.ns_id -->
+<!-- 	</if> -->
+	
+	<!-- Filter by aspects --> 
+	<if test="aspects != null and aspects.size() > 0">
+	and n.id in
+	(
+		SELECT n.id FROM alf_node n
+			<foreach item="aspect" index="index" collection="aspects" open="" separator="" close="">
+				JOIN alf_node_aspects a${index} ON a${index}.node_id = n.id
+				JOIN alf_qname q${index} ON q${index}.id = a${index}.qname_id 
+				JOIN alf_namespace ns${index} ON ns${index}.id = q${index}.ns_id
+            </foreach>
+		WHERE  
+			<foreach item="aspect" index="index" collection="aspects" open="(" separator=" AND " close=")">
+				('{' || ns${index}.uri || '}' || q${index}.local_name) = #{aspect}
+			</foreach> 
+	)
+	</if>
+	where
+	<if test="(allowedTypes!= null and allowedTypes.size() > 0)|| (mimeTypes!= null and mimeTypes.size() > 0)">
+		n.id in 
+		(
+			select n.id from alf_node n
+			join alf_qname q on q.id=n.type_qname_id
+			join alf_namespace ns on ns.id=q.ns_id
+			join alf_node_properties p on p.node_id=n.id
+			join alf_content_data d on d.id=p.long_value
+			join alf_content_url u on u.id=d.content_url_id 
+			
+			<!-- Filter by mimetypes --> 
+			<if test="mimeTypes != null and mimeTypes.size() > 0">
+				join alf_mimetype m on d.content_mimetype_id = m.id and m.mimetype_str in 
+				<foreach item="mime" index="index" collection="mimeTypes" open="(" separator="," close=")">
+		        		#{mime}
+		      	</foreach>
+		    </if>
+		    
+		    <!-- Filter by node types --> 
+		    <if test="allowedTypes != null and allowedTypes.size() > 0">
+				where
+				concat('{', ns.uri, '}', q.local_name) in
+      			<foreach item="type" index="index" collection="allowedTypes" open="(" separator="," close=")">
+        			#{type}
+      			</foreach>
+			</if>
+		) and
+	</if>
+	
+	<!-- Filter by name extension -->
+	<if test="excludedNameExtension != null and excludedNameExtension.size() > 0">
+    	n.id not in
 		(
 			select n.id from alf_node n
 			join alf_node_properties np on np.node_id=n.id
@@ -98,11 +221,42 @@
 			</foreach>
 		) and
 	</if>
-    node.store_id = #{storeId} and
-    node.transaction_id &gt; #{minId} and
-    node.transaction_id &lt;= #{maxId}
-    order by
-    node.transaction_id ASC
+	
+	<!-- Filter by properties --> 
+<!-- 	<if test="properties != null and properties.size() > 0"> -->
+<!-- 	( -->
+		<!-- Boolean value -->
+<!-- 		(concat('{', nsp.uri, '}', qp.local_name, ':', pr.boolean_value) in -->
+<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
+<!--         	#{prop} -->
+<!--       	</foreach> and pr.persisted_type_n=1) or -->
+<!--       	Long value -->
+<!--       	(concat('{', nsp.uri, '}', qp.local_name, ':', pr.long_value) in -->
+<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
+<!--         	#{prop} -->
+<!--       	</foreach> and pr.persisted_type_n=3) or -->
+<!--       	Float value -->
+<!--       	(concat('{', nsp.uri, '}', qp.local_name, ':', pr.float_value) in -->
+<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
+<!--         	#{prop} -->
+<!--       	</foreach> and pr.persisted_type_n=4) or -->
+<!--       	Double value -->
+<!--       	(concat('{', nsp.uri, '}', qp.local_name, ':', pr.double_value) in -->
+<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
+<!--         	#{prop} -->
+<!--       	</foreach> and pr.persisted_type_n=5) or -->
+<!--       	String value -->
+<!--       	(concat('{', nsp.uri, '}', qp.local_name, ':', pr.string_value) in -->
+<!--       	<foreach item="prop" index="index" collection="properties" open="(" separator="," close=")"> -->
+<!--         	#{prop} -->
+<!--       	</foreach> and pr.persisted_type_n=6) -->
+<!--     ) and -->
+<!-- 	</if> -->
+	
+	n.store_id = #{storeId} and
+	n.transaction_id &gt; #{minId} and
+    n.transaction_id &lt;= #{maxId}
+	order by n.transaction_id ASC
   </select>
   
   <select id="select_NodeIndexesByUuid" parameterType="NodeIndexLoad" resultMap="result_NodeIndex">

--- a/alfresco-indexer-webscripts/src/main/amp/config/alfresco/module/alfresco-indexer-webscripts/alfresco-global.properties
+++ b/alfresco-indexer-webscripts/src/main/amp/config/alfresco/module/alfresco-indexer-webscripts/alfresco-global.properties
@@ -4,10 +4,10 @@ indexer.share.url.prefix = http://${share.host}:${share.port}/share
 indexer.preview.url.prefix = http://${alfresco.host}:${alfresco.port}/alfresco/service
 indexer.thumbnail.url.prefix = http://${alfresco.host}:${alfresco.port}/alfresco/service
 
-indexer.changes.nodesperacl=10
-indexer.changes.nodespertxn=10
+indexer.changes.nodesperacl=1000
+indexer.changes.nodespertxn=1000
 
-indexer.changes.allowedTypes={http://www.alfresco.org/model/content/1.0}content,{http://www.alfresco.org/model/content/1.0}folder
+indexer.changes.allowedTypes={http://www.alfresco.org/model/content/1.0}content
 
 ##Exclude the nodes with the name that end with these extensions.
 indexer.changes.excludedNameExtension=.ftl

--- a/alfresco-indexer-webscripts/src/main/amp/config/alfresco/module/alfresco-indexer-webscripts/alfresco-global.properties
+++ b/alfresco-indexer-webscripts/src/main/amp/config/alfresco/module/alfresco-indexer-webscripts/alfresco-global.properties
@@ -11,3 +11,8 @@ indexer.changes.allowedTypes={http://www.alfresco.org/model/content/1.0}content,
 
 ##Exclude the nodes with the name that end with these extensions.
 indexer.changes.excludedNameExtension=.ftl
+
+indexer.changes.allowedProperties=
+indexer.changes.allowedAspects=
+indexer.changes.allowedMimetypes=
+indexer.changes.allowedSites=

--- a/alfresco-indexer-webscripts/src/main/amp/config/alfresco/module/alfresco-indexer-webscripts/context/jmx-context.xml
+++ b/alfresco-indexer-webscripts/src/main/amp/config/alfresco/module/alfresco-indexer-webscripts/context/jmx-context.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!DOCTYPE beans PUBLIC '-//SPRING//DTD BEAN//EN' 'http://www.springframework.org/dtd/spring-beans.dtd'>
+
+<beans>
+	<bean id="indexingServiceMBean" class="org.alfresco.consulting.indexer.dao.IndexingDaoJMX">
+		<property name="indexingDaoImpl" ref="indexingService" />
+	</bean>
+
+	<bean id="indexingServiceJmxExporter" class="org.springframework.jmx.export.MBeanExporter">
+		<property name="assembler" ref="assembler" />
+		<property name="beans">
+			<map>
+				<entry key="Alfresco:Name=Indexing,Type=indexingService" value-ref="indexingServiceMBean" />
+			</map>
+		</property>
+	</bean>
+
+	<bean id="jmxAttributeSource" class="org.springframework.jmx.export.annotation.AnnotationJmxAttributeSource" />
+
+	<bean id="assembler" class="org.springframework.jmx.export.assembler.MetadataMBeanInfoAssembler">
+		<property name="attributeSource" ref="jmxAttributeSource" />
+	</bean>
+</beans>

--- a/alfresco-indexer-webscripts/src/main/amp/config/alfresco/module/alfresco-indexer-webscripts/context/service-context.xml
+++ b/alfresco-indexer-webscripts/src/main/amp/config/alfresco/module/alfresco-indexer-webscripts/context/service-context.xml
@@ -29,6 +29,7 @@
   <bean id="indexingService"
         class="org.alfresco.consulting.indexer.dao.IndexingDaoImpl">
     <property name="sqlSessionTemplate" ref="indexingSqlSessionTemplate"/>
+    <property name="serviceRegistry" ref="ServiceRegistry" />
     <property name="allowedTypes">
       <bean class="org.springframework.util.StringUtils" factory-method="commaDelimitedListToSet">
         <constructor-arg type="java.lang.String" value="${indexer.changes.allowedTypes}"/>
@@ -37,6 +38,26 @@
     <property name="excludedNameExtension">
       <bean class="org.springframework.util.StringUtils" factory-method="commaDelimitedListToSet">
         <constructor-arg type="java.lang.String" value="${indexer.changes.excludedNameExtension}"/>
+      </bean>
+    </property>
+    <property name="properties">
+      <bean class="org.springframework.util.StringUtils" factory-method="commaDelimitedListToSet">
+        <constructor-arg type="java.lang.String" value="${indexer.changes.allowedProperties}"/>
+      </bean>
+    </property>
+    <property name="aspects">
+      <bean class="org.springframework.util.StringUtils" factory-method="commaDelimitedListToSet">
+        <constructor-arg type="java.lang.String" value="${indexer.changes.allowedAspects}"/>
+      </bean>
+    </property>
+    <property name="mimeTypes">
+      <bean class="org.springframework.util.StringUtils" factory-method="commaDelimitedListToSet">
+        <constructor-arg type="java.lang.String" value="${indexer.changes.allowedMimetypes}"/>
+      </bean>
+    </property>
+    <property name="sites">
+      <bean class="org.springframework.util.StringUtils" factory-method="commaDelimitedListToSet">
+        <constructor-arg type="java.lang.String" value="${indexer.changes.allowedSites}"/>
       </bean>
     </property>
   </bean>

--- a/alfresco-indexer-webscripts/src/main/amp/config/alfresco/module/alfresco-indexer-webscripts/module-context.xml
+++ b/alfresco-indexer-webscripts/src/main/amp/config/alfresco/module/alfresco-indexer-webscripts/module-context.xml
@@ -19,4 +19,5 @@
 
 <beans>
   <import resource="classpath:alfresco/module/${project.artifactId}/context/service-context.xml" />
+  <import resource="classpath:alfresco/module/${project.artifactId}/context/jmx-context.xml" />
 </beans>

--- a/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/dao/IndexingDaoImpl.java
+++ b/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/dao/IndexingDaoImpl.java
@@ -126,42 +126,45 @@ public class IndexingDaoImpl
             filteredNodes= new ArrayList<NodeEntity>();
             
             for(NodeEntity node:nodes){
-
-                boolean shouldBeAdded=true;
-                NodeRef nodeRef= new NodeRef(node.getStore().getStoreRef(),node.getUuid());
                 
-                //Filter by site
-                if(filters.get("SITE")){
-                    String siteName=siteService.getSiteShortName(nodeRef);
-                    shouldBeAdded= siteName!=null && this.sites.contains(siteName);
-                }
-                
-                //Filter by properties
-                if(filters.get("PROPERTIES") && shouldBeAdded){
-                    for(String prop:this.properties){
-                        
-                        int pos=prop.lastIndexOf(":");
-                        String qName=null;
-                        String value=null;
-                        
-                        if(pos!=-1 && (prop.length()-1)>pos){
-                            qName=prop.substring(0, pos);
-                            value= prop.substring(pos+1,prop.length());
-                        }
-                        
-                        if(StringUtils.isEmpty(qName) || StringUtils.isEmpty(value)){
-                            //Invalid property
-                            continue;
-                        }
-                        
-                        Serializable rawValue= nodeService.getProperty(nodeRef, QName.createQName(qName));
-                        shouldBeAdded=shouldBeAdded && value.equals(rawValue);
-                        
+               boolean shouldBeAdded=true;
+               NodeRef nodeRef= new NodeRef(node.getStore().getStoreRef(),node.getUuid());
+                    
+               if(nodeService.exists(nodeRef)){
+                    
+                    //Filter by site
+                    if(filters.get("SITE")){
+                        String siteName=siteService.getSiteShortName(nodeRef);
+                        shouldBeAdded= siteName!=null && this.sites.contains(siteName);
                     }
-                }
-                
-                if(shouldBeAdded){
-                    filteredNodes.add(node);
+                    
+                    //Filter by properties
+                    if(filters.get("PROPERTIES") && shouldBeAdded){
+                        for(String prop:this.properties){
+                            
+                            int pos=prop.lastIndexOf(":");
+                            String qName=null;
+                            String value=null;
+                            
+                            if(pos!=-1 && (prop.length()-1)>pos){
+                                qName=prop.substring(0, pos);
+                                value= prop.substring(pos+1,prop.length());
+                            }
+                            
+                            if(StringUtils.isEmpty(qName) || StringUtils.isEmpty(value)){
+                                //Invalid property
+                                continue;
+                            }
+                            
+                            Serializable rawValue= nodeService.getProperty(nodeRef, QName.createQName(qName));
+                            shouldBeAdded=shouldBeAdded && value.equals(rawValue);
+                            
+                        }
+                    }
+                    
+                    if(shouldBeAdded){
+                        filteredNodes.add(node);
+                    }
                 }
             }
         }else{

--- a/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/dao/IndexingDaoImpl.java
+++ b/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/dao/IndexingDaoImpl.java
@@ -1,92 +1,259 @@
 package org.alfresco.consulting.indexer.dao;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import org.alfresco.consulting.indexer.entities.NodeBatchLoadEntity;
 import org.alfresco.consulting.indexer.entities.NodeEntity;
+import org.alfresco.service.ServiceRegistry;
+import org.alfresco.service.cmr.repository.NodeRef;
+import org.alfresco.service.cmr.repository.NodeService;
 import org.alfresco.service.cmr.repository.StoreRef;
+import org.alfresco.service.cmr.site.SiteService;
+import org.alfresco.service.namespace.QName;
 import org.alfresco.util.Pair;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.ibatis.session.RowBounds;
 import org.mybatis.spring.SqlSessionTemplate;
 
-import java.util.List;
-import java.util.Set;
+public class IndexingDaoImpl
+{
 
-public class IndexingDaoImpl {
+    private static final String SELECT_NODES_BY_ACLS = "alfresco.index.select_NodeIndexesByAclChangesetId";
+    private static final String SELECT_NODES_BY_TXNS = "alfresco.index.select_NodeIndexesByTransactionId";
+    private static final String SELECT_NODES_BY_UUID = "alfresco.index.select_NodeIndexesByUuid";
 
-  private static final String SELECT_NODES_BY_ACLS = "alfresco.index.select_NodeIndexesByAclChangesetId";
-  private static final String SELECT_NODES_BY_TXNS = "alfresco.index.select_NodeIndexesByTransactionId";
-  private static final String SELECT_NODES_BY_UUID = "alfresco.index.select_NodeIndexesByUuid";
+    protected static final Log logger = LogFactory.getLog(IndexingDaoImpl.class);
 
-  protected static final Log logger = LogFactory.getLog(IndexingDaoImpl.class);
-  
-  private SqlSessionTemplate template;
-  private Set<String> allowedTypes;
-  private Set<String> excludedNameExtension;
+    private SqlSessionTemplate template;
+    private SiteService siteService;
+    private NodeService nodeService;
+    
+    private Set<String> allowedTypes;
+    private Set<String> excludedNameExtension;
+    private Set<String> properties;
+    private Set<String> aspects;
+    private Set<String> mimeTypes;
+    private Set<String> sites;
 
-  public List<NodeEntity> getNodesByAclChangesetId(Pair<Long, StoreRef> store, Long lastAclChangesetId, int maxResults) {
-    StoreRef storeRef = store.getSecond();
-    if (maxResults <= 0 || maxResults == Integer.MAX_VALUE) {
-      throw new IllegalArgumentException("Maximum results must be a reasonable number.");
+    public List<NodeEntity> getNodesByAclChangesetId(Pair<Long, StoreRef> store, Long lastAclChangesetId, int maxResults)
+    {
+        StoreRef storeRef = store.getSecond();
+        if (maxResults <= 0 || maxResults == Integer.MAX_VALUE)
+        {
+            throw new IllegalArgumentException("Maximum results must be a reasonable number.");
+        }
+
+        logger.debug("[getNodesByAclChangesetId] On Store " + storeRef.getProtocol() + "://" + storeRef.getIdentifier());
+
+        NodeBatchLoadEntity nodeLoadEntity = new NodeBatchLoadEntity();
+        nodeLoadEntity.setStoreId(store.getFirst());
+        nodeLoadEntity.setStoreProtocol(storeRef.getProtocol());
+        nodeLoadEntity.setStoreIdentifier(storeRef.getIdentifier());
+        nodeLoadEntity.setMinId(lastAclChangesetId);
+        nodeLoadEntity.setMaxId(lastAclChangesetId + maxResults);
+        nodeLoadEntity.setAllowedTypes(this.allowedTypes);
+        nodeLoadEntity.setExcludedNameExtension(this.excludedNameExtension);
+//        nodeLoadEntity.setProperties(this.properties);
+        nodeLoadEntity.setAspects(this.aspects);
+        nodeLoadEntity.setMimeTypes(this.mimeTypes);
+
+        return filterNodes((List<NodeEntity>) template.selectList(SELECT_NODES_BY_ACLS, nodeLoadEntity, new RowBounds(0,
+                Integer.MAX_VALUE)));
     }
 
-    logger.debug("[getNodesByAclChangesetId] On Store "+storeRef.getProtocol()+"://"+storeRef.getIdentifier());
+    public List<NodeEntity> getNodesByTransactionId(Pair<Long, StoreRef> store, Long lastTransactionId, int maxResults)
+    {
+        StoreRef storeRef = store.getSecond();
+        if (maxResults <= 0 || maxResults == Integer.MAX_VALUE)
+        {
+            throw new IllegalArgumentException("Maximum results must be a reasonable number.");
+        }
 
-    NodeBatchLoadEntity nodeLoadEntity = new NodeBatchLoadEntity();
-    nodeLoadEntity.setStoreId(store.getFirst());
-    nodeLoadEntity.setStoreProtocol(storeRef.getProtocol());
-    nodeLoadEntity.setStoreIdentifier(storeRef.getIdentifier());
-    nodeLoadEntity.setMinId(lastAclChangesetId);
-    nodeLoadEntity.setMaxId(lastAclChangesetId+maxResults);
-    nodeLoadEntity.setAllowedTypes(this.allowedTypes);
-    nodeLoadEntity.setExcludedNameExtension(this.excludedNameExtension);
+        logger.debug("[getNodesByTransactionId] On Store " + storeRef.getProtocol() + "://" + storeRef.getIdentifier());
 
-    return (List<NodeEntity>) template.selectList(SELECT_NODES_BY_ACLS, nodeLoadEntity, new RowBounds(0, Integer.MAX_VALUE));
-  }
+        NodeBatchLoadEntity nodeLoadEntity = new NodeBatchLoadEntity();
+        nodeLoadEntity.setStoreId(store.getFirst());
+        nodeLoadEntity.setStoreProtocol(storeRef.getProtocol());
+        nodeLoadEntity.setStoreIdentifier(storeRef.getIdentifier());
+        nodeLoadEntity.setMinId(lastTransactionId);
+        nodeLoadEntity.setMaxId(lastTransactionId + maxResults);
+        nodeLoadEntity.setAllowedTypes(this.allowedTypes);
+        nodeLoadEntity.setExcludedNameExtension(this.excludedNameExtension);
+//        nodeLoadEntity.setProperties(this.properties);
+        nodeLoadEntity.setAspects(this.aspects);
+        nodeLoadEntity.setMimeTypes(this.mimeTypes);
 
-  public List<NodeEntity> getNodesByTransactionId(Pair<Long, StoreRef> store, Long lastTransactionId, int maxResults) {
-    StoreRef storeRef = store.getSecond();
-    if (maxResults <= 0 || maxResults == Integer.MAX_VALUE) {
-      throw new IllegalArgumentException("Maximum results must be a reasonable number.");
+        return filterNodes((List<NodeEntity>) template.selectList(SELECT_NODES_BY_TXNS, nodeLoadEntity, new RowBounds(0,
+                Integer.MAX_VALUE)));
     }
 
-    logger.debug("[getNodesByTransactionId] On Store "+storeRef.getProtocol()+"://"+storeRef.getIdentifier());
+    public NodeEntity getNodeByUuid(Pair<Long, StoreRef> store, String uuid)
+    {
+        StoreRef storeRef = store.getSecond();
 
-    NodeBatchLoadEntity nodeLoadEntity = new NodeBatchLoadEntity();
-    nodeLoadEntity.setStoreId(store.getFirst());
-    nodeLoadEntity.setStoreProtocol(storeRef.getProtocol());
-    nodeLoadEntity.setStoreIdentifier(storeRef.getIdentifier());
-    nodeLoadEntity.setMinId(lastTransactionId);
-    nodeLoadEntity.setMaxId(lastTransactionId+maxResults);
-    nodeLoadEntity.setAllowedTypes(this.allowedTypes);
-    nodeLoadEntity.setExcludedNameExtension(this.excludedNameExtension);
+        logger.debug("[getNodeByUuid] On Store " + storeRef.getProtocol() + "://" + storeRef.getIdentifier());
 
-    return (List<NodeEntity>) template.selectList(SELECT_NODES_BY_TXNS, nodeLoadEntity, new RowBounds(0, Integer.MAX_VALUE));
-  }
-  
-  public NodeEntity getNodeByUuid(Pair<Long, StoreRef> store, String uuid) {
-      StoreRef storeRef = store.getSecond();
+        NodeBatchLoadEntity nodeLoadEntity = new NodeBatchLoadEntity();
+        nodeLoadEntity.setStoreId(store.getFirst());
+        nodeLoadEntity.setStoreProtocol(storeRef.getProtocol());
+        nodeLoadEntity.setStoreIdentifier(storeRef.getIdentifier());
+        nodeLoadEntity.setUuid(uuid);
 
-      logger.debug("[getNodeByUuid] On Store "+storeRef.getProtocol()+"://"+storeRef.getIdentifier());
+        return (NodeEntity) template.selectOne(SELECT_NODES_BY_UUID, nodeLoadEntity);
+    }
+    
+    /**
+     * Filter the nodes based on some parameters
+     * @param nodes
+     * @return
+     */
+    private List<NodeEntity> filterNodes(List<NodeEntity> nodes)
+    {
+        List<NodeEntity> filteredNodes= null;
+        
+        //Filter by sites
+        Map<String,Boolean> filters=getFilters();
+        
+        if(filters.values().contains(Boolean.TRUE)){
+            
+            filteredNodes= new ArrayList<NodeEntity>();
+            
+            for(NodeEntity node:nodes){
 
-      NodeBatchLoadEntity nodeLoadEntity = new NodeBatchLoadEntity();
-      nodeLoadEntity.setStoreId(store.getFirst());
-      nodeLoadEntity.setStoreProtocol(storeRef.getProtocol());
-      nodeLoadEntity.setStoreIdentifier(storeRef.getIdentifier());
-      nodeLoadEntity.setUuid(uuid);
-
-      return (NodeEntity) template.selectOne(SELECT_NODES_BY_UUID, nodeLoadEntity);
+                boolean shouldBeAdded=true;
+                NodeRef nodeRef= new NodeRef(node.getStore().getStoreRef(),node.getUuid());
+                
+                //Filter by site
+                if(filters.get("SITE")){
+                    String siteName=siteService.getSiteShortName(nodeRef);
+                    shouldBeAdded= siteName!=null && this.sites.contains(siteName);
+                }
+                
+                //Filter by properties
+                if(filters.get("PROPERTIES") && shouldBeAdded){
+                    for(String prop:this.properties){
+                        
+                        int pos=prop.lastIndexOf(":");
+                        String qName=null;
+                        String value=null;
+                        
+                        if(pos!=-1 && (prop.length()-1)>pos){
+                            qName=prop.substring(0, pos);
+                            value= prop.substring(pos+1,prop.length());
+                        }
+                        
+                        if(StringUtils.isEmpty(qName) || StringUtils.isEmpty(value)){
+                            //Invalid property
+                            continue;
+                        }
+                        
+                        Serializable rawValue= nodeService.getProperty(nodeRef, QName.createQName(qName));
+                        shouldBeAdded=shouldBeAdded && value.equals(rawValue);
+                        
+                    }
+                }
+                
+                if(shouldBeAdded){
+                    filteredNodes.add(node);
+                }
+            }
+        }else{
+            filteredNodes=nodes;
+        }
+        return filteredNodes;
     }
 
+    /**
+     * Get existing filters
+     * @return
+     */
+    private Map<String,Boolean> getFilters()
+    {
+        Map<String,Boolean> filters= new HashMap<String, Boolean>(2);
+        //Site filter
+        filters.put("SITE", this.sites!=null && this.sites.size() > 0);
+        //Properties filter
+        filters.put("PROPERTIES", this.properties!=null && this.properties.size() > 0);
+        
+        return filters;
+    }
 
-  public void setSqlSessionTemplate(SqlSessionTemplate sqlSessionTemplate) {
-    this.template = sqlSessionTemplate;
-  }
-  public void setAllowedTypes(Set<String> allowedTypes) {
-    this.allowedTypes = allowedTypes;
-  }
-  
-  public void setExcludedNameExtension(Set<String> excludedNameExtension){
-      this.excludedNameExtension= excludedNameExtension;
-  }
+    public void setSqlSessionTemplate(SqlSessionTemplate sqlSessionTemplate)
+    {
+        this.template = sqlSessionTemplate;
+    }
+    
+    public void setServiceRegistry(ServiceRegistry serviceRegistry){
+        this.siteService=serviceRegistry.getSiteService();
+        this.nodeService= serviceRegistry.getNodeService();
+    }
+
+    public void setAllowedTypes(Set<String> allowedTypes)
+    {
+        this.allowedTypes = allowedTypes;
+    }
+
+    public Set<String> getAllowedTypes()
+    {
+        return this.allowedTypes;
+    }
+
+    public void setExcludedNameExtension(Set<String> excludedNameExtension)
+    {
+        this.excludedNameExtension = excludedNameExtension;
+    }
+
+    public Set<String> getExcludedNameExtension()
+    {
+        return this.excludedNameExtension;
+    }
+
+    public void setProperties(Set<String> properties)
+    {
+        this.properties = properties;
+    }
+
+    public Set<String> getProperties()
+    {
+        return this.properties;
+    }
+
+    public void setAspects(Set<String> aspects)
+    {
+        this.aspects = aspects;
+    }
+
+    public Set<String> getAspects()
+    {
+
+        return this.aspects;
+    }
+
+    public void setMimeTypes(Set<String> mimeTypes)
+    {
+        this.mimeTypes = mimeTypes;
+    }
+
+    public Set<String> getMimeTypes()
+    {
+        return this.mimeTypes;
+    }
+    
+    public void setSites(Set<String> sites)
+    {
+        this.sites = sites;
+    }
+
+    public Set<String> getSites()
+    {
+        return this.sites;
+    }
+
 }

--- a/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/dao/IndexingDaoJMX.java
+++ b/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/dao/IndexingDaoJMX.java
@@ -1,0 +1,143 @@
+package org.alfresco.consulting.indexer.dao;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+import org.springframework.jmx.export.annotation.ManagedAttribute;
+import org.springframework.jmx.export.annotation.ManagedResource;
+
+/**
+ * @author iarroyo
+ *
+ */
+
+@ManagedResource
+public class IndexingDaoJMX
+{
+
+    private IndexingDaoImpl indexingDaoImpl;
+
+    private final static String DELIMITER = ",";
+
+    public void setIndexingDaoImpl(IndexingDaoImpl indexingDaoImpl)
+    {
+        this.indexingDaoImpl = indexingDaoImpl;
+    }
+
+    @ManagedAttribute
+    public void setAllowedTypes(String allowedTypes)
+    {
+        Set<String> types = tokenizeString(allowedTypes);
+        indexingDaoImpl.setAllowedTypes(types);
+    }
+
+    @ManagedAttribute
+    public String getAllowedTypes()
+    {
+        return collectionToString(indexingDaoImpl.getAllowedTypes(), DELIMITER);
+    }
+
+    @ManagedAttribute
+    public void setExcludedNameExtension(String exludedNameExtension)
+    {
+        Set<String> excludedNameExtensions = tokenizeString(exludedNameExtension);
+        indexingDaoImpl.setExcludedNameExtension(excludedNameExtensions);
+    }
+
+    @ManagedAttribute
+    public String getExcludedNameExtension()
+    {
+        return collectionToString(indexingDaoImpl.getExcludedNameExtension(), DELIMITER);
+    }
+
+    @ManagedAttribute
+    public void setProperties(String properties)
+    {
+        Set<String> allowedProperties = tokenizeString(properties);
+        indexingDaoImpl.setProperties(allowedProperties);
+    }
+
+    @ManagedAttribute
+    public String getProperties()
+    {
+        return collectionToString(indexingDaoImpl.getProperties(), DELIMITER);
+    }
+
+    @ManagedAttribute
+    public void setAspects(String aspects)
+    {
+        Set<String> allowedAspects = tokenizeString(aspects);
+        indexingDaoImpl.setAspects(allowedAspects);
+    }
+
+    @ManagedAttribute
+    public String getAspects()
+    {
+        return collectionToString(this.indexingDaoImpl.getAspects(), DELIMITER);
+    }
+
+    @ManagedAttribute
+    public void setMimeTypes(String mimetypes)
+    {
+        Set<String> allowedMimetypes = tokenizeString(mimetypes);
+        indexingDaoImpl.setMimeTypes(allowedMimetypes);
+    }
+
+    @ManagedAttribute
+    public String getMimeTypes()
+    {
+        return collectionToString(indexingDaoImpl.getMimeTypes(), DELIMITER);
+    }
+    
+    @ManagedAttribute
+    public void setSites(String sites)
+    {
+        Set<String> allowedSites = tokenizeString(sites);
+        indexingDaoImpl.setSites(allowedSites);
+    }
+
+    @ManagedAttribute
+    public String getSites()
+    {
+        return collectionToString(indexingDaoImpl.getSites(), DELIMITER);
+    }
+
+    private Set<String> tokenizeString(String str)
+    {
+
+        Set<String> tokens = null;
+        StringTokenizer tokenizer = new StringTokenizer(str, DELIMITER);
+
+        if (tokenizer.countTokens() > 0)
+        {
+            tokens = new HashSet<String>();
+            while (tokenizer.hasMoreTokens())
+            {
+                tokens.add(tokenizer.nextToken().trim());
+            }
+        }
+
+        return tokens;
+    }
+
+    private String collectionToString(Set<String> collection, String delimiter)
+    {
+
+        StringBuilder sb = new StringBuilder();
+        if (collection != null)
+        {
+            for (String str : collection)
+            {
+                if (sb.length() > 0)
+                {
+                    sb.append(delimiter);
+                }
+                sb.append(str);
+            }
+        }
+
+        return sb.toString();
+    }
+
+}

--- a/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/entities/NodeBatchLoadEntity.java
+++ b/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/entities/NodeBatchLoadEntity.java
@@ -9,6 +9,9 @@ public class NodeBatchLoadEntity extends org.alfresco.repo.domain.node.ibatis.No
   private String uuid;
   private Set<String> allowedTypes;
   private Set<String> excludedNameExtension;
+//  private Set<String> properties;
+  private Set<String> aspects;
+  private Set<String> mimeTypes;
 
   //These input values will be set on all returned NodeEntity objects returned by iBatis mappers
   private String storeProtocol;
@@ -68,5 +71,29 @@ public class NodeBatchLoadEntity extends org.alfresco.repo.domain.node.ibatis.No
   
   public Set<String> getExcludedNameExtension(){
       return this.excludedNameExtension;
+  }
+  
+//  public void setProperties(Set<String> properties){
+//      this.properties=properties;
+//  }
+//  
+//  public Set<String> getProperties(){
+//      return this.properties;
+//  }
+  
+  public void setAspects(Set<String> aspects){
+      this.aspects=aspects;
+  }
+  
+  public Set<String> getAspects(){
+      return this.aspects;
+  }
+  
+  public void setMimeTypes(Set<String> mimeTypes){
+      this.mimeTypes=mimeTypes;
+  }
+  
+  public Set<String> getMimeTypes(){
+      return this.mimeTypes;
   }
 }

--- a/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/utils/Utils.java
+++ b/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/utils/Utils.java
@@ -1,0 +1,32 @@
+package org.alfresco.consulting.indexer.utils;
+
+import java.util.Iterator;
+
+import org.alfresco.service.cmr.repository.Path;
+
+public class Utils
+{
+    
+    public static String getSiteName(Path path) {
+        //Fetching Path and preparing for rendering
+        Iterator<Path.Element> pathIter = path.iterator();
+
+        //Scan the Path to find the Alfresco Site name
+        boolean siteFound = false;
+        while(pathIter.hasNext()) {
+          String pathElement = pathIter.next().getElementString();
+          //Stripping out namespace from PathElement
+          int firstChar = pathElement.lastIndexOf('}');
+          if (firstChar > 0) {
+            pathElement = pathElement.substring(firstChar+1);
+          }
+          if (pathElement.equals("sites")) {
+            siteFound = true;
+          } else if (siteFound) {
+            return pathElement;
+          }
+        }
+        return null;
+      }
+
+}

--- a/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/webscripts/NodeChangesWebScript.java
+++ b/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/webscripts/NodeChangesWebScript.java
@@ -29,7 +29,7 @@ import java.util.*;
  * - Node content
  * - Node ACLs
  *
- * Please check src/main/amp/config/alfresco/extension/templates/webscripts/com/findwise/alfresco/changes.get.desc.xml
+ * Please check src/main/amp/config/alfresco/extension/templates/webscripts/org/alfresco/consulting/indexer/webscripts/changes.get.desc.xml
  * to know more about the RestFul interface to invoke the WebScript
  *
  * List of pending activities (or TODOs)
@@ -101,16 +101,34 @@ public class NodeChangesWebScript extends DeclarativeWebScript {
     List<NodeEntity> nodesFromTxns = indexingService.getNodesByTransactionId(store, lastTxnId, maxTxns);
     if (nodesFromTxns != null && nodesFromTxns.size() > 0) {
       nodes.addAll(nodesFromTxns);
-      lastTxnId = nodesFromTxns.get(nodesFromTxns.size()-1).getTransactionId();
     }
+    
+    //Set the last database transaction ID or increment it by maxTxns
+    Long lastTxnIdDB= indexingService.getLastTransactionID();
 
+    if((lastTxnId+maxTxns) > lastTxnIdDB){
+        lastTxnId=lastTxnIdDB;
+    }else{
+        lastTxnId+=maxTxns;
+    }
+    
+    
+    
     if (lastAclChangesetId == null) {
       lastAclChangesetId = new Long(0);
     }
     List<NodeEntity> nodesFromAcls = indexingService.getNodesByAclChangesetId(store, lastAclChangesetId, maxAclChangesets);
     if (nodesFromAcls != null && nodesFromAcls.size() > 0) {
       nodes.addAll(nodesFromAcls);
-      lastAclChangesetId = nodesFromAcls.get(nodesFromAcls.size()-1).getAclChangesetId();
+    }
+    
+    //Set the last database aclChangeSet ID or increment it by maxAclChangesets
+    Long lastAclChangesetIdDB= indexingService.getLastAclChangeSetID();
+
+    if((lastAclChangesetId+maxAclChangesets) > lastAclChangesetIdDB){
+        lastAclChangesetId=lastAclChangesetIdDB;
+    }else{
+        lastAclChangesetId+=maxAclChangesets;
     }
     
     //elapsed time

--- a/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/webscripts/NodeChangesWebScript.java
+++ b/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/webscripts/NodeChangesWebScript.java
@@ -43,6 +43,9 @@ public class NodeChangesWebScript extends DeclarativeWebScript {
   @Override
   protected Map<String, Object> executeImpl(WebScriptRequest req, Status status, Cache cache) {
 
+    //start time  
+    long startTime = System.currentTimeMillis();  
+      
     //Fetching request params
     Map<String, String> templateArgs = req.getServiceMatch().getTemplateVars();
     String storeId = templateArgs.get("storeId");
@@ -108,6 +111,9 @@ public class NodeChangesWebScript extends DeclarativeWebScript {
       nodes.addAll(nodesFromAcls);
       lastAclChangesetId = nodesFromAcls.get(nodesFromAcls.size()-1).getAclChangesetId();
     }
+    
+    //elapsed time
+    long elapsedTime = System.currentTimeMillis() - startTime;
 
     //Render them out
     Map<String, Object> model = new HashMap<String, Object>(1, 1.0f);
@@ -119,6 +125,7 @@ public class NodeChangesWebScript extends DeclarativeWebScript {
     model.put("storeId", storeId);
     model.put("storeProtocol", storeProtocol);
     model.put("propertiesUrlTemplate", propertiesUrlTemplate);
+    model.put("elapsedTime", elapsedTime);
 
     //This allows to call the static method QName.createQName from the FTL template
     try {

--- a/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/webscripts/NodeChangesWebScript.java
+++ b/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/webscripts/NodeChangesWebScript.java
@@ -129,35 +129,35 @@ public class NodeChangesWebScript extends DeclarativeWebScript {
   {
       
       //Types filter
-      List<String> types= (List<String>) indexingParams.get("typesFilter");
+      List<String> types= (List<String>) indexingParams.get("typeFilters");
       
       if(types!=null && types.size()>0){
           this.indexingService.setAllowedTypes(new HashSet(types));
       }
       
        //Site filter
-       List<String> sites= (List<String>) indexingParams.get("sitesFilter");
+       List<String> sites= (List<String>) indexingParams.get("siteFilters");
       
        if(sites!=null && sites.size()>0){
            this.indexingService.setSites(new HashSet(sites));
        }
           
        //Mymetype filter
-       List<String> mimetypes= (List<String>) indexingParams.get("mimetypesFilter");
+       List<String> mimetypes= (List<String>) indexingParams.get("mimetypeFilters");
        
        if(mimetypes!=null && mimetypes.size()>0){
            this.indexingService.setMimeTypes(new HashSet(mimetypes));
        }
           
        //Aspect filter
-       List<String> aspects= (List<String>) indexingParams.get("aspectsFilter");
+       List<String> aspects= (List<String>) indexingParams.get("aspectFilters");
        
        if(aspects!=null && aspects.size()>0){
            this.indexingService.setAspects(new HashSet(aspects));
        }
           
        //Metadata filter
-       Map<String,String> auxMap= (Map<String, String>) indexingParams.get("metadataFilter");
+       Map<String,String> auxMap= (Map<String, String>) indexingParams.get("metadataFilters");
        
        if(auxMap!=null && auxMap.size()>0){
            

--- a/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/webscripts/NodeChangesWebScript.java
+++ b/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/webscripts/NodeChangesWebScript.java
@@ -12,6 +12,7 @@ import org.alfresco.repo.domain.qname.QNameDAO;
 import org.alfresco.service.cmr.repository.StoreRef;
 import org.alfresco.service.namespace.NamespaceService;
 import org.alfresco.util.Pair;
+import org.apache.commons.collections.map.HashedMap;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.json.simple.JSONObject;
@@ -145,6 +146,12 @@ public class NodeChangesWebScript extends DeclarativeWebScript {
 
   private void setIndexingFilters(JSONObject indexingParams)
   {
+      
+      //Reset filters
+      this.indexingService.setSites(Collections.<String> emptySet());
+      this.indexingService.setMimeTypes(Collections.<String> emptySet());
+      this.indexingService.setAspects(Collections.<String> emptySet());
+      this.indexingService.setProperties(Collections.<String> emptySet());
       
       //Types filter
       List<String> types= (List<String>) indexingParams.get("typeFilters");

--- a/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/webscripts/NodeChangesWebScript.java
+++ b/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/webscripts/NodeChangesWebScript.java
@@ -2,8 +2,10 @@ package org.alfresco.consulting.indexer.webscripts;
 
 import org.alfresco.consulting.indexer.dao.IndexingDaoImpl;
 import org.alfresco.consulting.indexer.entities.NodeEntity;
+
 import freemarker.ext.beans.BeansWrapper;
 import freemarker.template.TemplateHashModel;
+
 import org.alfresco.error.AlfrescoRuntimeException;
 import org.alfresco.repo.domain.node.NodeDAO;
 import org.alfresco.repo.domain.qname.QNameDAO;
@@ -12,6 +14,8 @@ import org.alfresco.service.namespace.NamespaceService;
 import org.alfresco.util.Pair;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.json.simple.JSONObject;
+import org.json.simple.JSONValue;
 import org.springframework.extensions.webscripts.*;
 
 import java.util.*;
@@ -51,13 +55,21 @@ public class NodeChangesWebScript extends DeclarativeWebScript {
     Long lastAclChangesetId = (lastAclChangesetIdString == null ? null : Long.valueOf(lastAclChangesetIdString));
     Integer maxTxns = (maxTxnsString == null ? maxNodesPerTxns : Integer.valueOf(maxTxnsString));
     Integer maxAclChangesets = (maxAclChangesetsString == null ? maxNodesPerAcl : Integer.valueOf(maxAclChangesetsString));
-
+    
+    JSONObject indexingFilters= (JSONObject) JSONValue.parse(req.getParameter("indexingFilters"));
+    
     logger.debug(String.format("Invoking Changes Webscript, using the following params\n" +
         "lastTxnId: %s\n" +
         "lastAclChangesetId: %s\n" +
         "storeId: %s\n" +
-        "storeProtocol: %s\n", lastTxnId, lastAclChangesetId, storeId, storeProtocol));
+        "storeProtocol: %s\n" +
+        "indexingFilters: %s\n", lastTxnId, lastAclChangesetId, storeId, storeProtocol, indexingFilters));
 
+    //Indexing filters
+    if(indexingFilters!=null){
+        setIndexingFilters(indexingFilters);
+    }
+    
     //Getting the Store ID on which the changes are requested
     Pair<Long,StoreRef> store = nodeDao.getStore(new StoreRef(storeProtocol, storeId));
     if(store == null)
@@ -111,6 +123,58 @@ public class NodeChangesWebScript extends DeclarativeWebScript {
     logger.debug(String.format("Attaching %s nodes to the WebScript template", nodes.size()));
 
     return model;
+  }
+
+  private void setIndexingFilters(JSONObject indexingParams)
+  {
+      
+      //Types filter
+      List<String> types= (List<String>) indexingParams.get("typesFilter");
+      
+      if(types!=null && types.size()>0){
+          this.indexingService.setAllowedTypes(new HashSet(types));
+      }
+      
+       //Site filter
+       List<String> sites= (List<String>) indexingParams.get("sitesFilter");
+      
+       if(sites!=null && sites.size()>0){
+           this.indexingService.setSites(new HashSet(sites));
+       }
+          
+       //Mymetype filter
+       List<String> mimetypes= (List<String>) indexingParams.get("mimetypesFilter");
+       
+       if(mimetypes!=null && mimetypes.size()>0){
+           this.indexingService.setMimeTypes(new HashSet(mimetypes));
+       }
+          
+       //Aspect filter
+       List<String> aspects= (List<String>) indexingParams.get("aspectsFilter");
+       
+       if(aspects!=null && aspects.size()>0){
+           this.indexingService.setAspects(new HashSet(aspects));
+       }
+          
+       //Metadata filter
+       Map<String,String> auxMap= (Map<String, String>) indexingParams.get("metadataFilter");
+       
+       if(auxMap!=null && auxMap.size()>0){
+           
+           Set<String> metadataParams= new HashSet<String>(auxMap.size());
+           Set<String> keys= auxMap.keySet();
+           StringBuilder sb= new StringBuilder();
+           
+           for(String key:keys){
+               sb.append(key).append(":").append(auxMap.get(key));
+               metadataParams.add(sb.toString());
+               //reset StringBuilder
+               sb.setLength(0);
+           }
+           this.indexingService.setProperties(metadataParams);
+       }
+      
+
   }
 
   private NamespaceService namespaceService;

--- a/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/webscripts/NodeChangesWebScript.java
+++ b/alfresco-indexer-webscripts/src/main/java/org/alfresco/consulting/indexer/webscripts/NodeChangesWebScript.java
@@ -18,6 +18,8 @@ import org.json.simple.JSONObject;
 import org.json.simple.JSONValue;
 import org.springframework.extensions.webscripts.*;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.*;
 
 /**
@@ -56,7 +58,16 @@ public class NodeChangesWebScript extends DeclarativeWebScript {
     Integer maxTxns = (maxTxnsString == null ? maxNodesPerTxns : Integer.valueOf(maxTxnsString));
     Integer maxAclChangesets = (maxAclChangesetsString == null ? maxNodesPerAcl : Integer.valueOf(maxAclChangesetsString));
     
-    JSONObject indexingFilters= (JSONObject) JSONValue.parse(req.getParameter("indexingFilters"));
+    JSONObject indexingFilters=null;
+    try
+    {
+        indexingFilters = req.getParameter("indexingFilters")!=null ? 
+               (JSONObject) JSONValue.parse(URLDecoder.decode(req.getParameter("indexingFilters"),"UTF-8")): null;
+    }
+    catch (UnsupportedEncodingException e)
+    {
+        throw new WebScriptException(e.getMessage(),e);
+    }
     
     logger.debug(String.format("Invoking Changes Webscript, using the following params\n" +
         "lastTxnId: %s\n" +

--- a/manifold-connector/src/main/java/org/alfresco/consulting/manifold/AlfrescoConnector.java
+++ b/manifold-connector/src/main/java/org/alfresco/consulting/manifold/AlfrescoConnector.java
@@ -205,10 +205,10 @@ public class AlfrescoConnector extends BaseRepositoryConnector {
   @Override
   public String[] getDocumentVersions(String[] documentIdentifiers, DocumentSpecification spec)
 		    throws ManifoldCFException, ServiceInterruption{
-	  /* TODO Implement Document Version Stuff because now it is needed. Probably the best option is 
-	   * Document Identifier + Filtering Configuration
-	   */
-	  return super.getDocumentVersions(documentIdentifiers, spec);
+	  String[] versions = new String[documentIdentifiers.length];
+	  for(int i = 0; i < documentIdentifiers.length; i++)
+		  versions[i] = ConfigurationHandler.getSpecificationVersion(spec) + documentIdentifiers[i];
+	  return versions;
   }
 
   private void processMetaData(RepositoryDocument rd,

--- a/manifold-connector/src/main/java/org/alfresco/consulting/manifold/AlfrescoConnector.java
+++ b/manifold-connector/src/main/java/org/alfresco/consulting/manifold/AlfrescoConnector.java
@@ -153,11 +153,16 @@ public class AlfrescoConnector extends BaseRepositoryConnector {
                                IProcessActivity activities, DocumentSpecification spec,
                                boolean[] scanOnly, int jobMode) throws ManifoldCFException,
           ServiceInterruption {
+	int i = 0;  
     for (String doc : documentIdentifiers) {
+    
+      String nextVersion = versions[i++];	
+    	
       // Calling again Alfresco API because Document's actions are lost from seeding method
       AlfrescoResponse response = alfrescoClient.fetchNode(doc);
       if(response.getDocumentList().isEmpty()){ // Not found seeded document. Could reflect an error in Alfresco
     	  logger.error("Invalid Seeded Document from Alfresco with ID {}", doc);
+    	  activities.noDocument(doc, nextVersion);
     	  continue;
       }
       Map<String, Object> map = response.getDocumentList().get(0); // Should be only one
@@ -178,6 +183,7 @@ public class AlfrescoConnector extends BaseRepositoryConnector {
           	processMetaData(rd,uuid);
           }catch(AlfrescoDownException e){
         	  logger.error("Invalid Document from Alfresco with ID {}", uuid, e);
+        	  activities.noDocument(doc, nextVersion);
         	  continue; // No Metadata, No Content....skip document
           }
         }
@@ -194,6 +200,15 @@ public class AlfrescoConnector extends BaseRepositoryConnector {
 		}
       }
     }
+  }
+  
+  @Override
+  public String[] getDocumentVersions(String[] documentIdentifiers, DocumentSpecification spec)
+		    throws ManifoldCFException, ServiceInterruption{
+	  /* TODO Implement Document Version Stuff because now it is needed. Probably the best option is 
+	   * Document Identifier + Filtering Configuration
+	   */
+	  return super.getDocumentVersions(documentIdentifiers, spec);
   }
 
   private void processMetaData(RepositoryDocument rd,

--- a/manifold-connector/src/main/java/org/alfresco/consulting/manifold/AlfrescoConnector.java
+++ b/manifold-connector/src/main/java/org/alfresco/consulting/manifold/AlfrescoConnector.java
@@ -121,7 +121,10 @@ public class AlfrescoConnector extends BaseRepositoryConnector {
       long transactionIdsProcessed;
       long aclChangesetsProcessed;
       do {
-        final AlfrescoResponse response = alfrescoClient.fetchNodes(lastTransactionId, lastAclChangesetId);
+        final AlfrescoResponse response = alfrescoClient.
+        		fetchNodes(lastTransactionId, 
+        				lastAclChangesetId,
+        				ConfigurationHandler.getFilters(spec));
         int count = 0;
         for (Map<String, Object> doc : response.getDocuments()) {
 //          String json = gson.toJson(doc);
@@ -148,7 +151,7 @@ public class AlfrescoConnector extends BaseRepositoryConnector {
     }
   }
 
-  @Override
+@Override
   public void processDocuments(String[] documentIdentifiers, String[] versions,
                                IProcessActivity activities, DocumentSpecification spec,
                                boolean[] scanOnly, int jobMode) throws ManifoldCFException,

--- a/manifold-connector/src/main/java/org/alfresco/consulting/manifold/AlfrescoConnector.java
+++ b/manifold-connector/src/main/java/org/alfresco/consulting/manifold/AlfrescoConnector.java
@@ -250,4 +250,31 @@ public class AlfrescoConnector extends BaseRepositoryConnector {
     ConfigurationHandler.viewConfiguration(threadContext, out, locale,
             parameters);
   }
+  
+  
+   @Override
+   public void outputSpecificationHeader(IHTTPOutput out, Locale locale, Specification os,
+     int connectionSequenceNumber, List<String> tabsArray)
+     throws ManifoldCFException, IOException{
+	   ConfigurationHandler.outputSpecificationHeader(out, locale, os, connectionSequenceNumber, tabsArray);
+   }
+   
+   @Override
+   public void outputSpecificationBody(IHTTPOutput out, Locale locale, Specification os,
+		    int connectionSequenceNumber, int actualSequenceNumber, String tabName) throws ManifoldCFException, IOException{
+	   ConfigurationHandler.outputSpecificationBody(out, locale, os, connectionSequenceNumber, actualSequenceNumber, tabName);
+   }
+   
+   @Override
+   public String processSpecificationPost(IPostParameters variableContext, Locale locale, Specification os,
+			  int connectionSequenceNumber) throws ManifoldCFException{
+	   return ConfigurationHandler.processSpecificationPost(variableContext, locale, os, connectionSequenceNumber);
+   }
+   
+   @Override
+   public void viewSpecification(IHTTPOutput out, Locale locale, Specification os,
+			  int connectionSequenceNumber) throws ManifoldCFException, IOException{
+	   ConfigurationHandler.viewSpecification(out, locale, os, connectionSequenceNumber);
+   }
+  
 }

--- a/manifold-connector/src/main/java/org/alfresco/consulting/manifold/AlfrescoConnector.java
+++ b/manifold-connector/src/main/java/org/alfresco/consulting/manifold/AlfrescoConnector.java
@@ -142,7 +142,7 @@ public class AlfrescoConnector extends BaseRepositoryConnector {
         lastAclChangesetId = response.getLastAclChangesetId();
 
         logger.info("transaction_id={}, acl_changeset_id={}", lastTransactionId, lastAclChangesetId);
-      } while (transactionIdsProcessed > 0 && aclChangesetsProcessed > 0);
+      } while (transactionIdsProcessed > 0 || aclChangesetsProcessed > 0);
 
       logger.info("Recording {} as last transaction id and {} as last changeset id", lastTransactionId, lastAclChangesetId);
       return lastTransactionId + "|" + lastAclChangesetId;

--- a/manifold-connector/src/main/java/org/alfresco/consulting/manifold/ConfigurationHandler.java
+++ b/manifold-connector/src/main/java/org/alfresco/consulting/manifold/ConfigurationHandler.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+import org.alfresco.consulting.indexer.client.AlfrescoFilters;
 import org.apache.commons.io.IOUtils;
 import org.apache.manifoldcf.core.i18n.Messages;
 import org.apache.manifoldcf.core.interfaces.ConfigParams;
@@ -450,4 +451,25 @@ public class ConfigurationHandler {
 	  }
 	  return builder.toString();
   }
+  
+  public static AlfrescoFilters getFilters(Specification spec) {
+		AlfrescoFilters filters = new AlfrescoFilters();
+		for(int i = 0; i < spec.getChildCount(); i++){
+			SpecificationNode node = spec.getChild(i);
+			if(node.getType().equals(NODE_SITE))
+				filters.addSiteFilter(node.getAttributeValue(ATTRIBUTE_SITE));
+			else if(node.getType().equals(NODE_MIMETYPE))
+				filters.addMimetypeFilter(node.getAttributeValue(ATTRIBUTE_MIMETYPE));
+			else if(node.getType().equals(NODE_ASPECT))
+				filters.addAspectFilter(
+						node.getAttributeValue(ATTRIBUTE_ASPECT_SOURCE),
+						node.getAttributeValue(ATTRIBUTE_ASPECT_TARGET));
+			else if(node.getType().equals(NODE_METADATA))
+				filters.addAspectFilter(
+						node.getAttributeValue(ATTRIBUTE_METADATA_SOURCE),
+						node.getAttributeValue(ATTRIBUTE_METADATA_TARGET));
+		}
+		
+		return filters;
+	}
 }

--- a/manifold-connector/src/main/java/org/alfresco/consulting/manifold/ConfigurationHandler.java
+++ b/manifold-connector/src/main/java/org/alfresco/consulting/manifold/ConfigurationHandler.java
@@ -465,7 +465,7 @@ public class ConfigurationHandler {
 						node.getAttributeValue(ATTRIBUTE_ASPECT_SOURCE),
 						node.getAttributeValue(ATTRIBUTE_ASPECT_TARGET));
 			else if(node.getType().equals(NODE_METADATA))
-				filters.addAspectFilter(
+				filters.addMetadataFilter(
 						node.getAttributeValue(ATTRIBUTE_METADATA_SOURCE),
 						node.getAttributeValue(ATTRIBUTE_METADATA_TARGET));
 		}

--- a/manifold-connector/src/main/java/org/alfresco/consulting/manifold/ConfigurationHandler.java
+++ b/manifold-connector/src/main/java/org/alfresco/consulting/manifold/ConfigurationHandler.java
@@ -445,6 +445,7 @@ public class ConfigurationHandler {
 		  Collection<String> vars = SPECIFICATION_MAP.get(node.getType());
 		  for(String var:vars)
 			  builder.append(node.getAttributeValue(var)).append("+");
+		  i++;
 	  }
 	  return builder.toString();
   }

--- a/manifold-connector/src/main/java/org/alfresco/consulting/manifold/ConfigurationHandler.java
+++ b/manifold-connector/src/main/java/org/alfresco/consulting/manifold/ConfigurationHandler.java
@@ -438,4 +438,16 @@ public class ConfigurationHandler {
 						  "</table>\n");
 	  }
   }
+  
+  public static String getSpecificationVersion(Specification os){
+	  StringBuilder builder = new StringBuilder();
+	  int i = 0;
+	  while(i < os.getChildCount()){
+		  SpecificationNode node = os.getChild(i);
+		  Collection<String> vars = SPECIFICATION_MAP.get(node.getType());
+		  for(String var:vars)
+			  builder.append(node.getAttributeValue(var)).append("+");
+	  }
+	  return builder.toString();
+  }
 }

--- a/manifold-connector/src/main/java/org/alfresco/consulting/manifold/ConfigurationHandler.java
+++ b/manifold-connector/src/main/java/org/alfresco/consulting/manifold/ConfigurationHandler.java
@@ -50,9 +50,7 @@ public class ConfigurationHandler {
   /** Node describing an Aspect */
   public static final String NODE_ASPECT = "aspect";
   /** Attribute describing an aspect name */
-  public static final String ATTRIBUTE_ASPECT_SOURCE = "aspect_source";
-  /** Attribute describing an aspect value */
-  public static final String ATTRIBUTE_ASPECT_TARGET = "aspect_value";
+  public static final String ATTRIBUTE_ASPECT = "aspect_name";
   
   /** Node describing a Metadata */
   public static final String NODE_METADATA = "metadata";
@@ -65,8 +63,7 @@ public class ConfigurationHandler {
 	        ImmutableMultimap.<String, String>builder().
 	        put(NODE_SITE, ATTRIBUTE_SITE).
 	        put(NODE_MIMETYPE, ATTRIBUTE_MIMETYPE).
-	        put(NODE_ASPECT, ATTRIBUTE_ASPECT_SOURCE).
-	        put(NODE_ASPECT, ATTRIBUTE_ASPECT_TARGET).
+	        put(NODE_ASPECT, ATTRIBUTE_ASPECT).
 	        put(NODE_METADATA, ATTRIBUTE_METADATA_SOURCE).
 	        put(NODE_METADATA, ATTRIBUTE_METADATA_TARGET).build();
 
@@ -462,8 +459,7 @@ public class ConfigurationHandler {
 				filters.addMimetypeFilter(node.getAttributeValue(ATTRIBUTE_MIMETYPE));
 			else if(node.getType().equals(NODE_ASPECT))
 				filters.addAspectFilter(
-						node.getAttributeValue(ATTRIBUTE_ASPECT_SOURCE),
-						node.getAttributeValue(ATTRIBUTE_ASPECT_TARGET));
+						node.getAttributeValue(ATTRIBUTE_ASPECT));
 			else if(node.getType().equals(NODE_METADATA))
 				filters.addMetadataFilter(
 						node.getAttributeValue(ATTRIBUTE_METADATA_SOURCE),

--- a/manifold-connector/src/main/java/org/alfresco/consulting/manifold/ConfigurationHandler.java
+++ b/manifold-connector/src/main/java/org/alfresco/consulting/manifold/ConfigurationHandler.java
@@ -3,6 +3,7 @@ package org.alfresco.consulting.manifold;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -15,8 +16,14 @@ import org.apache.manifoldcf.core.interfaces.IHTTPOutput;
 import org.apache.manifoldcf.core.interfaces.IPostParameters;
 import org.apache.manifoldcf.core.interfaces.IThreadContext;
 import org.apache.manifoldcf.core.interfaces.ManifoldCFException;
+import org.apache.manifoldcf.core.interfaces.Specification;
+import org.apache.manifoldcf.core.interfaces.SpecificationNode;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.app.VelocityEngine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMultimap;
 
 public class ConfigurationHandler {
   private static final String PARAM_PROTOCOL = "protocol";
@@ -27,6 +34,40 @@ public class ConfigurationHandler {
   private static final String PARAM_STORE_ID = "storeid";
   private static final String PARAM_USERNAME = "username";
   private static final String PARAM_PASSWORD = "password";
+  
+  // Output Specification for Filtering
+  /** Node describing a Site */
+  public static final String NODE_SITE = "site";
+  /** Attribute describing a site name */
+  public static final String ATTRIBUTE_SITE = "site_name";
+  
+  /** Node describing a MimeType */
+  public static final String NODE_MIMETYPE = "mimetype";
+  /** Attribute describing a MimeType name */
+  public static final String ATTRIBUTE_MIMETYPE = "mimetype_name";
+  
+  /** Node describing an Aspect */
+  public static final String NODE_ASPECT = "aspect";
+  /** Attribute describing an aspect name */
+  public static final String ATTRIBUTE_ASPECT_SOURCE = "aspect_source";
+  /** Attribute describing an aspect value */
+  public static final String ATTRIBUTE_ASPECT_TARGET = "aspect_value";
+  
+  /** Node describing a Metadata */
+  public static final String NODE_METADATA = "metadata";
+  /** Attribute describing an aspect name */
+  public static final String ATTRIBUTE_METADATA_SOURCE = "metadata_source";
+  /** Attribute describing an aspect value */
+  public static final String ATTRIBUTE_METADATA_TARGET = "metadata_value";
+  
+  public static final ImmutableMultimap<String, String> SPECIFICATION_MAP =
+	        ImmutableMultimap.<String, String>builder().
+	        put(NODE_SITE, ATTRIBUTE_SITE).
+	        put(NODE_MIMETYPE, ATTRIBUTE_MIMETYPE).
+	        put(NODE_ASPECT, ATTRIBUTE_ASPECT_SOURCE).
+	        put(NODE_ASPECT, ATTRIBUTE_ASPECT_TARGET).
+	        put(NODE_METADATA, ATTRIBUTE_METADATA_SOURCE).
+	        put(NODE_METADATA, ATTRIBUTE_METADATA_TARGET).build();
 
   private static final String EDIT_CONFIG_HEADER = "editConfiguration.js";
   private static final String EDIT_CONFIG_SERVER = "editConfiguration_Server.html";
@@ -43,6 +84,8 @@ public class ConfigurationHandler {
     DEFAULT_CONFIGURATION_PARAMETERS.put(PARAM_USERNAME, "");
     DEFAULT_CONFIGURATION_PARAMETERS.put(PARAM_PASSWORD, "");
   }
+  
+  private static final Logger logger = LoggerFactory.getLogger(ConfigurationHandler.class);
 
   private ConfigurationHandler() {
   }
@@ -113,5 +156,286 @@ public class ConfigurationHandler {
     StringWriter w = new StringWriter();
     velocityEngine.mergeTemplate(VIEW_CONFIG, "UTF-8", context, w);
     out.print(w.toString());
+  }
+  
+  public static void outputSpecificationHeader(IHTTPOutput out, Locale locale, Specification os,
+    int connectionSequenceNumber, List<String> tabsArray)
+    throws ManifoldCFException, IOException
+  {
+    String seqPrefix = "s"+connectionSequenceNumber+"_";
+    tabsArray.add("Alfresco Filtering Configuration");
+    
+    out.print(
+    		"<script type=\"text/javascript\">\n"+
+    		"<!--\n"+
+    		"function "+seqPrefix+"checkSpecification()\n"+
+    		"{\n"+
+    		"  return true;\n"+
+    		"}\n"+
+    		"\n");
+    
+    for(String node:SPECIFICATION_MAP.keySet()){
+    	out.print(
+    			"function "+seqPrefix+"add"+node+"()\n"+
+    			"{\n");
+    	Collection<String> vars = SPECIFICATION_MAP.get(node);
+    	for(String var:vars){
+    		out.print(
+    				"if (editjob."+seqPrefix+var+".value == \"\")\n"+
+        			"  {\n"+
+        			"    alert(\"Value of "+ node + "." + var + " can't be NULL" +"\");\n"+
+        			"    editjob."+seqPrefix+var+".focus();\n"+
+        			"    return;\n"+
+        			"  }\n"
+    				);
+    	}
+    			
+    	out.print("editjob."+seqPrefix+node+"_op.value=\"Add\";\n"+
+    			"  postFormSetAnchor(\""+seqPrefix+"+"+node+"\");\n"+
+    			"}\n"+
+    			"\n"+
+    	"function "+seqPrefix+"delete"+node+"(i)\n"+
+    			"{\n"+
+    			"  // Set the operation\n"+
+    			"  eval(\"editjob."+seqPrefix+node+"_\"+i+\"_op.value=\\\"Delete\\\"\");\n"+
+    			"  // Submit\n"+
+    			"  if (editjob."+seqPrefix+node+"_count.value==i)\n"+
+    			"    postFormSetAnchor(\""+seqPrefix+node+"\");\n"+
+    			"  else\n"+
+    			"    postFormSetAnchor(\""+seqPrefix+node+"_\"+i)\n"+
+    			"  // Undo, so we won't get two deletes next time\n"+
+    			"  eval(\"editjob."+seqPrefix+node+"_\"+i+\"_op.value=\\\"Continue\\\"\");\n"+
+    			"}\n"+
+    			"\n");
+    }
+    		
+    out.print("\n"+
+    		"\n"+
+    		"//-->\n"+
+    		"</script>\n");		
+  }
+
+  
+  public static void outputSpecificationBody(IHTTPOutput out, Locale locale, Specification os,
+		  int connectionSequenceNumber, int actualSequenceNumber, String tabName)
+				  throws ManifoldCFException, IOException
+  {
+	  String seqPrefix = "s"+connectionSequenceNumber+"_";
+	  int i;
+	  // Field Mapping tab
+	  if (tabName.equals("Alfresco Filtering Configuration") && connectionSequenceNumber == actualSequenceNumber)
+	  {
+		  for(String node:SPECIFICATION_MAP.keySet()){
+			  out.print(
+					  "<table class=\"displaytable\">\n"+
+							  "  <tr><td class=\"separator\" colspan=\"2\"><hr/></td></tr>\n"+
+							  "  <tr>\n"+
+							  "    <td class=\"description\"><nobr>" + node + " filtering:</nobr></td>\n"+
+							  "    <td class=\"boxcell\">\n"+
+							  "      <table class=\"formtable\">\n"+
+							  "        <tr class=\"formheaderrow\">\n"+
+							  "          <td class=\"formcolumnheader\"></td>\n");
+			  Collection<String> vars = SPECIFICATION_MAP.get(node);
+			  for(String var:vars){
+				  out.print("<td class=\"formcolumnheader\"><nobr>" + var + "</nobr></td>\n");
+			  }
+			  out.print("</tr>\n");
+			  
+			  int fieldCounter = 0;
+			  i = 0;
+			  while (i < os.getChildCount()) {
+				  SpecificationNode sn = os.getChild(i++);
+				  if (sn.getType().equals(node)) {
+					  String prefix = seqPrefix+node+"_" + Integer.toString(fieldCounter);
+					  out.print(
+							  "        <tr class=\""+(((fieldCounter % 2)==0)?"evenformrow":"oddformrow")+"\">\n"+
+									  "          <td class=\"formcolumncell\">\n"+
+									  "            <a name=\""+prefix+"\">\n"+
+									  "              <input type=\"button\" value=\"Delete\" alt=\"Delete"+Integer.toString(fieldCounter+1)+"\" onclick='javascript:"+seqPrefix+"delete"+node+"("+Integer.toString(fieldCounter)+");'/>\n"+
+									  "              <input type=\"hidden\" name=\""+prefix+"_op\" value=\"Continue\"/>\n");
+					  for(String var:vars){
+						  out.print("<input type=\"hidden\" name=\""+prefix+"_"+var+"\" value=\""+org.apache.manifoldcf.ui.util.Encoder.attributeEscape(sn.getAttributeValue(var))+"\"/>\n");
+					  }
+
+					  out.print("            </a>\n"+
+							  "          </td>\n");
+					  for(String var:vars){
+						  out.print(
+								  "       <td class=\"formcolumncell\">\n"+
+										  "            <nobr>"+org.apache.manifoldcf.ui.util.Encoder.bodyEscape(sn.getAttributeValue(var))+"</nobr>\n"+
+								  "          </td>\n");
+					  }
+					  fieldCounter++;
+
+				  }
+			  }
+			  
+			  if (fieldCounter == 0)
+		      {
+		        out.print(
+		        		"<tr class=\"formrow\"><td class=\"formmessage\" colspan=\"3\">No Filtering Configuration Specified</td></tr>\n");
+		      }
+			  
+			  out.print(
+						"        <tr class=\"formrow\"><td class=\"formseparator\" colspan=\"3\"><hr/></td></tr>\n"+
+						"        <tr class=\"formrow\">\n"+
+						"          <td class=\"formcolumncell\">\n"+
+						"            <a name=\""+seqPrefix+node+"\">\n"+
+						"              <input type=\"button\" value=\"Add\" alt=\"Add " + node + "\" onclick=\"javascript:"+seqPrefix+"add"+node+"();\"/>\n"+
+						"            </a>\n"+
+						"            <input type=\"hidden\" name=\""+seqPrefix+node+"_count\" value=\""+fieldCounter+"\"/>\n"+
+						"            <input type=\"hidden\" name=\""+seqPrefix+node+"_op\" value=\"Continue\"/>\n"+
+						"          </td>\n");
+			  for(String var:vars){
+				  out.print("          <td class=\"formcolumncell\">\n"+
+						"            <nobr><input type=\"text\" size=\"15\" name=\""+seqPrefix+var+"\" value=\"\"/></nobr>\n"+
+						"          </td>\n");
+			  }
+
+			 out.print("</tr>\n"+
+						"      </table>\n"+
+						"    </td>\n"+
+						"  </tr>\n");
+						
+
+		  }
+	  }
+	  else{
+	      for(String node:SPECIFICATION_MAP.keySet()){
+	    	  i = 0;
+		      int fieldCounter = 0;  
+		      while (i < os.getChildCount()) {
+		    	  SpecificationNode sn = os.getChild(i++);
+		    	  if(sn.getType().equals(node)){
+		    		String prefix = seqPrefix+node+"_" + Integer.toString(fieldCounter);  
+		    		for(String var:SPECIFICATION_MAP.get(node)){
+		    			out.print(
+		    					"<input type=\"hidden\" name=\""+prefix+"_"+var+"\" value=\""+org.apache.manifoldcf.ui.util.Encoder.attributeEscape(sn.getAttributeValue(var))+"\"/>\n");
+		    		}
+		    		fieldCounter++;
+		    	  }
+		      }
+		      
+		      out.print("<input type=\"hidden\" name=\""+seqPrefix+node+"_count\" value=\""+Integer.toString(fieldCounter)+"\"/>\n");
+	      }
+	    }
+	  }
+		  
+  public static String processSpecificationPost(IPostParameters variableContext, Locale locale, Specification os,
+		  int connectionSequenceNumber) throws ManifoldCFException {
+	  // Remove old Nodes
+	  int i;
+
+	  String seqPrefix = "s"+connectionSequenceNumber+"_";
+	 	 	  
+	  for(String node:SPECIFICATION_MAP.keySet()){
+		  
+		  String x = variableContext.getParameter(seqPrefix+node+"_count");
+		  if (x != null && x.length() > 0){
+			  
+			  i = 0;
+			  while (i < os.getChildCount())
+			  {
+				  SpecificationNode specNode = os.getChild(i);
+				  if (specNode.getType().equals(node))
+					  os.removeChild(i);
+				  else
+					  i++;
+			  }
+
+			  Collection<String> vars = SPECIFICATION_MAP.get(node);
+
+			  int count = Integer.parseInt(x);
+			  i = 0;
+			  while (i < count)
+			  {
+				  String prefix = seqPrefix+node+"_"+Integer.toString(i);
+				  String op = variableContext.getParameter(prefix+"_op");
+				  if (op == null || !op.equals("Delete"))
+				  {
+					  SpecificationNode specNode = new SpecificationNode(node);
+					  for(String var:vars){
+						  String value = variableContext.getParameter(prefix+"_"+var);
+						  if(value == null)
+							  value = "";
+						  specNode.setAttribute(var, value);
+					  }
+					  os.addChild(os.getChildCount(), specNode);
+				  }
+				  i++;
+			  }
+
+			  String addop = variableContext.getParameter(seqPrefix+node+"_op");
+			  if (addop != null && addop.equals("Add"))
+			  {
+				  SpecificationNode specNode = new SpecificationNode(node);
+				  for(String var:vars){
+					  String value = variableContext.getParameter(seqPrefix+var);
+					  if(value == null)
+						  value = "";
+					  specNode.setAttribute(var, value);
+				  }
+				  os.addChild(os.getChildCount(), specNode);
+			  }
+		  }
+	  }
+
+	  return null;
+  }
+  
+  public static void viewSpecification(IHTTPOutput out, Locale locale, Specification os,
+		  int connectionSequenceNumber)
+				  throws ManifoldCFException, IOException
+  {
+	  int i = 0;
+
+	  for(String node:SPECIFICATION_MAP.keySet()){
+		  Collection<String> vars = SPECIFICATION_MAP.get(node);
+		  out.print(
+				  "\n"+
+						  "<table class=\"displaytable\">\n"+
+						  "  <tr>\n"+
+						  "    <td class=\"description\"><nobr>Alfresco "+ node + " Filtering Configuration</nobr></td>\n"+
+						  "    <td class=\"boxcell\">\n"+
+						  "      <table class=\"formtable\">\n"+
+						  "        <tr class=\"formheaderrow\">\n");
+		  for(String var:vars)
+			  out.print(
+					  "          <td class=\"formcolumnheader\"><nobr>" + var + "</nobr></td>\n");
+						  
+		 out.print("        </tr>\n");
+		 
+		 int fieldCounter = 0;
+		  i = 0;
+		 
+		  while (i < os.getChildCount()) {
+			  SpecificationNode sn = os.getChild(i++);
+			  if (sn.getType().equals(node)) {
+				  out.print(
+						  "        <tr class=\""+(((fieldCounter % 2)==0)?"evenformrow":"oddformrow")+"\">\n");
+				  for(String var:vars)
+					  out.print(
+								  "          <td class=\"formcolumncell\">\n"+
+								  "            <nobr>"+org.apache.manifoldcf.ui.util.Encoder.bodyEscape(sn.getAttributeValue(var))+"</nobr>\n"+
+								  "          </td>\n");
+				  out.print(
+								  "        </tr>\n");
+				  fieldCounter++;
+			  }
+		  }
+
+		  if (fieldCounter == 0)
+		  {
+			  out.print(
+					  "        <tr class=\"formrow\"><td class=\"formmessage\" colspan=\"3\">No Filtering Configuration Specificied for " + node + "</td></tr>\n"
+					  );
+		  }
+		  out.print(
+				  "      </table>\n"+
+						  "    </td>\n"+
+						  "  </tr>\n"+
+						  "  </tr>\n"+
+						  "</table>\n");
+	  }
   }
 }


### PR DESCRIPTION
Hi @maoo, 

This is a major change again. We have extended the whole project for supporting content filtering in the crawling process. This is the list of the new features:
- Included Configuration at Job Level (Job Specification) for filtering by Alfresco Site, Content Mimetype, Alfresco Aspect or Metadata key/value
- Included Filtering Configuration in the AlfrescoClient interface fetchNodes method. The filtering configuration is now sent to the server to be used by the webscript
- Modified the queries for including the filtering options. Now the queries are complex, so we have tested a lot to ensure the performance
- Included shareUrlPath for any kind of content to use it at content URL when indexing
